### PR TITLE
이메일 인증 코드 재전송을 위한 api 구현 (#38)

### DIFF
--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
@@ -12,11 +12,10 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Email;
 
 @Slf4j
 @RestController
@@ -56,6 +55,17 @@ public class MemberController {
         headers.set(TOKEN_KEY, token);
 
         return new ResponseEntity<>(headers, HttpStatus.OK);
+    }
+
+    @PostMapping("/members/{memberId}/authcode")
+    public ResponseEntity sendAuthCodeEmail(@Email @PathVariable String memberId) {
+
+        memberService.sendAuthCodeToEmail(memberId);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return new ResponseEntity(headers, HttpStatus.OK);
     }
 
     @PostMapping("/email-auth")

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
@@ -58,7 +58,7 @@ public class MemberController {
     }
 
     @PostMapping("/members/{memberId}/authcode")
-    public ResponseEntity sendAuthCodeEmail(@Email @PathVariable String memberId) {
+    public ResponseEntity sendAuthCodeEmail(@PathVariable String memberId) {
 
         memberService.sendAuthCodeToEmail(memberId);
 

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/MailService.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/MailService.java
@@ -2,7 +2,7 @@ package com.sproutt.eussyaeussyaapi.application;
 
 public interface MailService {
 
-    String sendAuthEmail(String to);
-
     void sendChangedPasswordMail();
+
+    void sendAuthEmail(String email, String authCode);
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/MailServiceImpl.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/MailServiceImpl.java
@@ -1,12 +1,10 @@
 package com.sproutt.eussyaeussyaapi.application;
 
-import com.sproutt.eussyaeussyaapi.utils.RandomGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,26 +12,24 @@ public class MailServiceImpl implements MailService {
 
     private final JavaMailSender mailSender;
 
-    @Transactional
-    public String sendAuthEmail(String to) {
-        String authenticationCode = RandomGenerator.createAuthenticationCode();
+    @Override
+    public void sendChangedPasswordMail() {
+
+    }
+
+    @Override
+    public void sendAuthEmail(String email, String authCode) {
+
         SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
 
-        simpleMailMessage.setTo(to);
+        simpleMailMessage.setTo(email);
         simpleMailMessage.setSubject("으쌰으쌰 계정 인증");
-        simpleMailMessage.setText("인증 코드: " + authenticationCode);
+        simpleMailMessage.setText("인증 코드: " + authCode);
 
         try {
             mailSender.send(simpleMailMessage);
         } catch (Exception e) {
             throw new MailSendException("메일 전송 에러");
         }
-
-        return authenticationCode;
-    }
-
-    @Override
-    public void sendChangedPasswordMail() {
-
     }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/member/MemberService.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/member/MemberService.java
@@ -14,4 +14,6 @@ public interface MemberService {
     Member joinWithOAuth2Provider();
 
     Member authenticateEmail(EmailAuthDTO emailAuthDTO);
+
+    Member sendAuthCodeToEmail(String email);
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/member/Member.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/member/Member.java
@@ -65,4 +65,8 @@ public class Member {
 
         return false;
     }
+
+    public void changeAuthCode(String authCode) {
+        this.authentication = authCode;
+    }
 }

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/MemberControllerTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/MemberControllerTest.java
@@ -1,12 +1,6 @@
 package com.sproutt.eussyaeussyaapi.api;
 
 
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sproutt.eussyaeussyaapi.api.member.EmailAuthDTO;
 import com.sproutt.eussyaeussyaapi.api.member.MemberController;
@@ -25,6 +19,12 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(MemberController.class)
@@ -52,12 +52,12 @@ public class MemberControllerTest {
         given(memberService.joinWithLocalProvider(joinDTO)).willReturn(member);
 
         ResultActions actions = mvc.perform(post("/members")
-            .content(asJsonString(joinDTO))
-            .contentType(MediaType.APPLICATION_JSON))
+                .content(asJsonString(joinDTO))
+                .contentType(MediaType.APPLICATION_JSON))
                                    .andDo(print());
 
         actions
-            .andExpect(status().isCreated());
+                .andExpect(status().isCreated());
     }
 
     @Test
@@ -67,10 +67,25 @@ public class MemberControllerTest {
         given(memberService.joinWithLocalProvider(joinDTO)).willThrow(new DuplicationMemberException());
 
         ResultActions actions = mvc.perform(post("/members")
-            .contentType(MediaType.APPLICATION_JSON)).andDo(print());
+                .contentType(MediaType.APPLICATION_JSON)).andDo(print());
 
         actions
-            .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void send_authCode_to_email() throws Exception {
+        Member member = MemberFactory.getDefaultMember();
+        String email = member.getMemberId();
+
+        given(memberService.sendAuthCodeToEmail(email)).willReturn(member);
+
+        ResultActions actions = mvc.perform(post("/members/" + email + "/authcode")
+                .contentType(MediaType.APPLICATION_JSON))
+                                   .andDo(print());
+
+        actions
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -85,12 +100,12 @@ public class MemberControllerTest {
         when(memberService.authenticateEmail(emailAuthDTO)).thenReturn(member);
 
         ResultActions actions = mvc.perform(post("/email-auth")
-            .content(asJsonString(emailAuthDTO))
-            .contentType(MediaType.APPLICATION_JSON))
+                .content(asJsonString(emailAuthDTO))
+                .contentType(MediaType.APPLICATION_JSON))
                                    .andDo(print());
 
         actions
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
     }
 
     private static String asJsonString(final Object object) {

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/exception/GlobalExceptionHandlerTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class globalExceptionHandlerTest {
+public class GlobalExceptionHandlerTest {
 
     @Autowired
     private TestRestTemplate template;

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/exception/globalExceptionHandlerTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/exception/globalExceptionHandlerTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class GlobalExceptionHanlderTest {
+public class globalExceptionHandlerTest {
 
     @Autowired
     private TestRestTemplate template;

--- a/src/test/java/com/sproutt/eussyaeussyaapi/application/MailServiceTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/application/MailServiceTest.java
@@ -1,5 +1,7 @@
 package com.sproutt.eussyaeussyaapi.application;
 
+import com.sproutt.eussyaeussyaapi.utils.RandomGenerator;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,17 +20,25 @@ public class MailServiceTest {
     @Autowired
     private MailService mailService;
 
+    private String authCode;
+
+
+    @BeforeEach
+    void setUp() {
+        authCode = RandomGenerator.createAuthenticationCode();
+    }
+
     @Test
     public void send_mail() {
         String to = "kjkun7631@naver.com";
 
-        mailService.sendAuthEmail(to);
+        mailService.sendAuthEmail(to, authCode);
     }
 
     @Test
     public void send_wrong_email_address() {
         String to = "wrongAddress";
 
-        assertThrows(MailSendException.class, () -> mailService.sendAuthEmail(to));
+        assertThrows(MailSendException.class, () -> mailService.sendAuthEmail(to, authCode));
     }
 }


### PR DESCRIPTION
- POST /members/{memberId}/authcode

close #38 