### PR TITLE
[Back] 로그인을 위한 JWT 기능 수정

### DIFF
--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/config/WebConfig.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/config/WebConfig.java
@@ -23,7 +23,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtInterceptor)
-                .excludePathPatterns("/signUp", "/social/*", "/then/*", "/members", "/", "/login");
+                .excludePathPatterns("/signUp", "/social/**", "/then/**", "/members/**", "/login", "/swagger-ui.html", "/webjars/**", "/swagger-resources/**", "/v2/**", "/email-auth", "/");
     }
 
     @Bean

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/config/WebConfig.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/config/WebConfig.java
@@ -23,7 +23,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtInterceptor)
-                .excludePathPatterns("/*");
+                .excludePathPatterns("/signUp", "/social/*", "/then/*", "/members", "/", "/login");
     }
 
     @Bean

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.sproutt.eussyaeussyaapi.api.dto.ErrorResponse;
 import com.sproutt.eussyaeussyaapi.api.dto.ValidateError;
 import com.sproutt.eussyaeussyaapi.api.oauth2.exception.OAuth2CommunicationException;
 import com.sproutt.eussyaeussyaapi.api.oauth2.exception.UnSupportedOAuth2Exception;
+import com.sproutt.eussyaeussyaapi.api.security.exception.InvalidTokenException;
 import com.sproutt.eussyaeussyaapi.domain.member.exceptions.DuplicationException;
 import com.sproutt.eussyaeussyaapi.domain.member.exceptions.NoSuchMemberException;
 import com.sproutt.eussyaeussyaapi.domain.member.exceptions.VerificationException;
@@ -55,6 +56,13 @@ public class GlobalExceptionHandler {
         log.info("response: {}", response.toString());
 
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(value = InvalidTokenException.class)
+    public ResponseEntity handleInvalidTokenException(InvalidTokenException exception) {
+        log.info("handleInvalidTokenException : {}", exception);
+
+        return ResponseEntity.badRequest().contentType(MediaType.APPLICATION_JSON).body(exception.getMessage());
     }
 
     @ExceptionHandler(value = DuplicationException.class)

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
@@ -24,7 +24,10 @@ import javax.validation.Valid;
 public class MemberController {
 
     @Value("${jwt.header}")
-    private String TOKEN_KEY;
+    private String tokenKey;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
 
     private final MemberService memberService;
     private final JwtHelper jwtHelper;
@@ -49,11 +52,11 @@ public class MemberController {
     public ResponseEntity loginMember(@Valid @RequestBody LoginDTO loginDTO) {
         Member loginMember = memberService.login(loginDTO);
 
-        String token = jwtHelper.createToken(loginMember.toJwtInfo());
+        String token = jwtHelper.createToken(secretKey, loginMember.toJwtInfo());
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set(TOKEN_KEY, token);
+        headers.set(tokenKey, token);
 
         return new ResponseEntity<>(headers, HttpStatus.OK);
     }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
@@ -23,7 +23,7 @@ import javax.validation.Valid;
 @Api(description = "으쌰으쌰 회원 관련 API", tags = {"Member - 담당자 : 김종근"})
 public class MemberController {
 
-    @Value("${token.key}")
+    @Value("${jwt.header}")
     private String TOKEN_KEY;
 
     private final MemberService memberService;
@@ -49,7 +49,7 @@ public class MemberController {
     public ResponseEntity loginMember(@Valid @RequestBody LoginDTO loginDTO) {
         Member loginMember = memberService.login(loginDTO);
 
-        String token = jwtHelper.createToken(loginMember);
+        String token = jwtHelper.createToken(loginMember.toJwtInfo());
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/member/dto/JwtMemberDTO.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/member/dto/JwtMemberDTO.java
@@ -1,6 +1,5 @@
 package com.sproutt.eussyaeussyaapi.api.member.dto;
 
-import com.sproutt.eussyaeussyaapi.domain.member.Provider;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,20 +12,11 @@ public class JwtMemberDTO {
 
     Long id;
 
-    private String memberId;
-
-    private String email;
-
     private String nickName;
 
-    private Provider provider;
-
     @Builder
-    public JwtMemberDTO(Long id, String memberId, String email, String nickName, Provider provider) {
+    public JwtMemberDTO(Long id, String nickName) {
         this.id = id;
-        this.memberId = memberId;
-        this.email = email;
         this.nickName = nickName;
-        this.provider = provider;
     }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/member/dto/JwtMemberDTO.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/member/dto/JwtMemberDTO.java
@@ -1,0 +1,32 @@
+package com.sproutt.eussyaeussyaapi.api.member.dto;
+
+import com.sproutt.eussyaeussyaapi.domain.member.Provider;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class JwtMemberDTO {
+
+    Long id;
+
+    private String memberId;
+
+    private String email;
+
+    private String nickName;
+
+    private Provider provider;
+
+    @Builder
+    public JwtMemberDTO(Long id, String memberId, String email, String nickName, Provider provider) {
+        this.id = id;
+        this.memberId = memberId;
+        this.email = email;
+        this.nickName = nickName;
+        this.provider = provider;
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/member/dto/LoginDTO.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/member/dto/LoginDTO.java
@@ -2,6 +2,7 @@ package com.sproutt.eussyaeussyaapi.api.member.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.validation.constraints.Email;
@@ -9,6 +10,7 @@ import javax.validation.constraints.NotBlank;
 
 @Getter
 @Setter
+@NoArgsConstructor
 public class LoginDTO {
 
     @Email

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialController.java
@@ -1,7 +1,6 @@
 package com.sproutt.eussyaeussyaapi.api.oauth2;
 
 import com.sproutt.eussyaeussyaapi.api.oauth2.dto.RequestUrlDto;
-import com.sproutt.eussyaeussyaapi.api.oauth2.exception.UnSupportedOAuth2Exception;
 import com.sproutt.eussyaeussyaapi.api.oauth2.service.OAuth2RequestService;
 import com.sproutt.eussyaeussyaapi.api.oauth2.service.SocialService;
 import com.sproutt.eussyaeussyaapi.api.security.JwtHelper;
@@ -12,11 +11,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/social")

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialController.java
@@ -59,7 +59,7 @@ public class SocialController {
         }
 
         socialService.login(loginMember);
-        String token = jwtHelper.createToken(loginMember);
+        String token = jwtHelper.createToken(loginMember.toJwtInfo());
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialController.java
@@ -35,8 +35,11 @@ public class SocialController {
     @Value("${social.facebook.url}")
     private String facebookRequestUrl;
 
-    @Value("${token.key}")
-    private String TOKEN_KEY;
+    @Value("${jwt.header}")
+    private String tokenKey;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
 
     @PostMapping("/login/{provider}")
     public ResponseEntity loginByProvider(@PathVariable String provider, @RequestParam String accessToken) {
@@ -59,11 +62,11 @@ public class SocialController {
         }
 
         socialService.login(loginMember);
-        String token = jwtHelper.createToken(loginMember.toJwtInfo());
+        String token = jwtHelper.createToken(secretKey, loginMember.toJwtInfo());
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set(TOKEN_KEY, token);
+        headers.set(tokenKey, token);
         return new ResponseEntity<>(headers, HttpStatus.OK);
     }
 

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtHelper.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtHelper.java
@@ -3,27 +3,18 @@ package com.sproutt.eussyaeussyaapi.api.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sproutt.eussyaeussyaapi.api.member.dto.JwtMemberDTO;
 import io.jsonwebtoken.*;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.io.UnsupportedEncodingException;
 import java.util.Date;
 
-@Slf4j
 @Component
 public class JwtHelper {
-
-    @Value("${jwt.secret}")
-    private String secretKey;
 
     private static final long VALID_MILLISECOND = 1000L * 60 * 60; // 1 hour
 
     private static final String CLAIM_KEY = "member";
 
-    public String createToken(JwtMemberDTO jwtMemberDTO) {
-
-        log.info("token: {}", secretKey);
+    public String createToken(String secretKey, JwtMemberDTO jwtMemberDTO) {
 
         Claims claims = Jwts.claims().setSubject(CLAIM_KEY);
         claims.put(CLAIM_KEY, jwtMemberDTO);
@@ -41,12 +32,12 @@ public class JwtHelper {
         return token;
     }
 
-    public JwtMemberDTO decryptToken(String token) {
+    public JwtMemberDTO decryptToken(String secretKey, String token) {
         Jws<Claims> claims = null;
 
         try {
 
-            claims = getClaims(token);
+            claims = getClaims(secretKey, token);
 
         } catch (Exception e) {
 
@@ -58,9 +49,9 @@ public class JwtHelper {
         return objectMapper.convertValue(claims.getBody().get(CLAIM_KEY), JwtMemberDTO.class);
     }
 
-    public boolean isUsable(String token) {
+    public boolean isUsable(String secretKey, String token) {
         try {
-            Jws<Claims> claims = getClaims(token);
+            Jws<Claims> claims = getClaims(secretKey, token);
 
             return !isExpired(claims);
 
@@ -73,24 +64,11 @@ public class JwtHelper {
         return claims.getBody().getExpiration().before(new Date());
     }
 
-    private Jws<Claims> getClaims(String token) {
+    private Jws<Claims> getClaims(String secretKey, String token) {
         Jws<Claims> claims = Jwts.parser()
-                                 .setSigningKey(this.generateKey())
+                                 .setSigningKey(secretKey)
                                  .parseClaimsJws(token);
 
         return claims;
-    }
-
-    private byte[] generateKey() {
-
-        byte[] key = null;
-
-        try {
-            key = secretKey.getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
-        }
-
-        return key;
     }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtInterceptor.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtInterceptor.java
@@ -1,6 +1,7 @@
 package com.sproutt.eussyaeussyaapi.api.security;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -10,7 +11,8 @@ import javax.servlet.http.HttpServletResponse;
 @Component
 public class JwtInterceptor implements HandlerInterceptor {
 
-    private final static String SECRET_KEY = "secret";
+    @Value("${jwt.header}")
+    private String SECRET_KEY;
 
     @Autowired
     private JwtHelper jwtHelper;
@@ -20,9 +22,9 @@ public class JwtInterceptor implements HandlerInterceptor {
 
         String token = request.getHeader(SECRET_KEY);
 
-//        if (token == null || !jwtService.isUsable(token)) {
-//            throw new RuntimeException();
-//        }
+        if (token == null || !jwtHelper.isUsable(token)) {
+            throw new RuntimeException();
+        }
 
         return true;
     }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtInterceptor.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtInterceptor.java
@@ -1,5 +1,6 @@
 package com.sproutt.eussyaeussyaapi.api.security;
 
+import com.sproutt.eussyaeussyaapi.api.security.exception.InvalidTokenException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -12,7 +13,10 @@ import javax.servlet.http.HttpServletResponse;
 public class JwtInterceptor implements HandlerInterceptor {
 
     @Value("${jwt.header}")
-    private String SECRET_KEY;
+    private String tokenKey;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
 
     @Autowired
     private JwtHelper jwtHelper;
@@ -20,10 +24,10 @@ public class JwtInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
 
-        String token = request.getHeader(SECRET_KEY);
+        String token = request.getHeader(tokenKey);
 
-        if (token == null || !jwtHelper.isUsable(token)) {
-            throw new RuntimeException();
+        if (token == null || !jwtHelper.isUsable(secretKey, token)) {
+            throw new InvalidTokenException();
         }
 
         return true;

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/security/exception/InvalidTokenException.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/security/exception/InvalidTokenException.java
@@ -1,0 +1,9 @@
+package com.sproutt.eussyaeussyaapi.api.security.exception;
+
+import com.sproutt.eussyaeussyaapi.utils.ExceptionMessage;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException() {
+        super(ExceptionMessage.INVALID_TOKEN);
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/member/Member.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/member/Member.java
@@ -1,5 +1,6 @@
 package com.sproutt.eussyaeussyaapi.domain.member;
 
+import com.sproutt.eussyaeussyaapi.api.member.dto.JwtMemberDTO;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -68,5 +69,15 @@ public class Member {
 
     public void changeAuthCode(String authCode) {
         this.authentication = authCode;
+    }
+
+    public JwtMemberDTO toJwtInfo() {
+        return JwtMemberDTO.builder()
+                .id(this.id)
+                .memberId(this.memberId)
+                .email(this.email)
+                .nickName(this.nickName)
+                .provider(this.provider)
+                .build();
     }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/member/Member.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/member/Member.java
@@ -74,10 +74,7 @@ public class Member {
     public JwtMemberDTO toJwtInfo() {
         return JwtMemberDTO.builder()
                 .id(this.id)
-                .memberId(this.memberId)
-                .email(this.email)
                 .nickName(this.nickName)
-                .provider(this.provider)
                 .build();
     }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/utils/ExceptionMessage.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/utils/ExceptionMessage.java
@@ -9,4 +9,5 @@ public class ExceptionMessage {
     public static final String OAUTH_COMMUNICATION_ERROR = "oauth 통신 중 오류가 발생하였습니다.";
     public static final String UNSUPPORT_OAUTH = "지원하지 않거나 존재하지 않는 oauth 입니다.";
     public static final String FAILED_VERIFICATION = "인증 실패";
+    public static final String INVALID_TOKEN = "유효하지 않은 토큰";
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,4 +40,4 @@ jasypt:
 
 api:
   cors:
-    allow-origins: http://49.50.164.30
+    allow-origins: http://localhost:8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,4 +40,4 @@ jasypt:
 
 api:
   cors:
-    allow-origins: http://localhost:8080
+    allow-origins: http://49.50.164.30

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,8 +21,9 @@ spring:
           starttls:
             enable: true
 
-token:
-  key: Authorization
+jwt:
+  header: Authorization
+  secret: secret
 
 social:
   github:

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/MemberControllerTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/MemberControllerTest.java
@@ -5,15 +5,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sproutt.eussyaeussyaapi.api.member.EmailAuthDTO;
 import com.sproutt.eussyaeussyaapi.api.member.MemberController;
 import com.sproutt.eussyaeussyaapi.api.member.dto.JoinDTO;
+import com.sproutt.eussyaeussyaapi.api.member.dto.JwtMemberDTO;
 import com.sproutt.eussyaeussyaapi.api.security.JwtHelper;
 import com.sproutt.eussyaeussyaapi.application.member.MemberService;
 import com.sproutt.eussyaeussyaapi.domain.member.Member;
+import com.sproutt.eussyaeussyaapi.domain.member.Provider;
 import com.sproutt.eussyaeussyaapi.domain.member.exceptions.DuplicationMemberException;
 import com.sproutt.eussyaeussyaapi.object.MemberFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -35,6 +39,10 @@ public class MemberControllerTest {
     private static final String DEFAULT_MEMBER_ID = "kjkun7631@naver.com";
     private static final String DEFAULT_PASSWORD = "12345aA!";
     private static final String DEFAULT_NAME = "test";
+    private String token;
+
+    @Value("${jwt.header}")
+    private String headerKey;
 
     @Autowired
     private MockMvc mvc;
@@ -45,6 +53,10 @@ public class MemberControllerTest {
     @MockBean
     private JwtHelper jwtHelper;
 
+    @BeforeEach
+    void setUp() {
+        token = jwtHelper.createToken(MemberFactory.getDefaultMember().toJwtInfo());
+    }
 
     @Test
     @DisplayName("회원가입 테스트(올바른 요청일 경우)")
@@ -86,6 +98,7 @@ public class MemberControllerTest {
         given(memberService.sendAuthCodeToEmail(email)).willReturn(member);
 
         ResultActions actions = mvc.perform(post("/members/" + email + "/authcode")
+                .header(headerKey, token)
                 .contentType(MediaType.APPLICATION_JSON))
                                    .andDo(print());
 
@@ -106,6 +119,7 @@ public class MemberControllerTest {
         when(memberService.authenticateEmail(emailAuthDTO)).thenReturn(member);
 
         ResultActions actions = mvc.perform(post("/email-auth")
+                .header(headerKey, token)
                 .content(asJsonString(emailAuthDTO))
                 .contentType(MediaType.APPLICATION_JSON))
                                    .andDo(print());
@@ -122,6 +136,7 @@ public class MemberControllerTest {
         when(memberService.isDuplicatedMemberId(member.getMemberId())).thenReturn(false);
 
         ResultActions actions = mvc.perform(get("/members/validate/memberid/{memberId}", member.getMemberId())
+                .header(headerKey, token)
                 .contentType(MediaType.APPLICATION_JSON))
                                    .andDo(print());
 
@@ -137,6 +152,7 @@ public class MemberControllerTest {
         when(memberService.isDuplicatedMemberId(member.getMemberId())).thenReturn(true);
 
         ResultActions actions = mvc.perform(get("/members/validate/memberid/{memberId}", member.getMemberId())
+                .header(headerKey, token)
                 .contentType(MediaType.APPLICATION_JSON))
                                    .andDo(print());
 
@@ -152,6 +168,7 @@ public class MemberControllerTest {
         when(memberService.isDuplicatedNickName(member.getNickName())).thenReturn(false);
 
         ResultActions actions = mvc.perform(get("/members/validate/nickname/{nickName}", member.getNickName())
+                .header(headerKey, token)
                 .contentType(MediaType.APPLICATION_JSON))
                                    .andDo(print());
 
@@ -167,6 +184,7 @@ public class MemberControllerTest {
         when(memberService.isDuplicatedNickName(member.getNickName())).thenReturn(true);
 
         ResultActions actions = mvc.perform(get("/members/validate/nickname/{nickName}", member.getNickName())
+                .header(headerKey, token)
                 .contentType(MediaType.APPLICATION_JSON))
                                    .andDo(print());
 

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/MemberControllerTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/MemberControllerTest.java
@@ -5,19 +5,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sproutt.eussyaeussyaapi.api.member.EmailAuthDTO;
 import com.sproutt.eussyaeussyaapi.api.member.MemberController;
 import com.sproutt.eussyaeussyaapi.api.member.dto.JoinDTO;
-import com.sproutt.eussyaeussyaapi.api.member.dto.JwtMemberDTO;
 import com.sproutt.eussyaeussyaapi.api.security.JwtHelper;
 import com.sproutt.eussyaeussyaapi.application.member.MemberService;
 import com.sproutt.eussyaeussyaapi.domain.member.Member;
-import com.sproutt.eussyaeussyaapi.domain.member.Provider;
 import com.sproutt.eussyaeussyaapi.domain.member.exceptions.DuplicationMemberException;
 import com.sproutt.eussyaeussyaapi.object.MemberFactory;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -39,10 +35,6 @@ public class MemberControllerTest {
     private static final String DEFAULT_MEMBER_ID = "kjkun7631@naver.com";
     private static final String DEFAULT_PASSWORD = "12345aA!";
     private static final String DEFAULT_NAME = "test";
-    private String token;
-
-    @Value("${jwt.header}")
-    private String headerKey;
 
     @Autowired
     private MockMvc mvc;
@@ -52,11 +44,6 @@ public class MemberControllerTest {
 
     @MockBean
     private JwtHelper jwtHelper;
-
-    @BeforeEach
-    void setUp() {
-        token = jwtHelper.createToken(MemberFactory.getDefaultMember().toJwtInfo());
-    }
 
     @Test
     @DisplayName("회원가입 테스트(올바른 요청일 경우)")
@@ -98,7 +85,6 @@ public class MemberControllerTest {
         given(memberService.sendAuthCodeToEmail(email)).willReturn(member);
 
         ResultActions actions = mvc.perform(post("/members/" + email + "/authcode")
-                .header(headerKey, token)
                 .contentType(MediaType.APPLICATION_JSON))
                                    .andDo(print());
 
@@ -119,7 +105,6 @@ public class MemberControllerTest {
         when(memberService.authenticateEmail(emailAuthDTO)).thenReturn(member);
 
         ResultActions actions = mvc.perform(post("/email-auth")
-                .header(headerKey, token)
                 .content(asJsonString(emailAuthDTO))
                 .contentType(MediaType.APPLICATION_JSON))
                                    .andDo(print());
@@ -136,7 +121,6 @@ public class MemberControllerTest {
         when(memberService.isDuplicatedMemberId(member.getMemberId())).thenReturn(false);
 
         ResultActions actions = mvc.perform(get("/members/validate/memberid/{memberId}", member.getMemberId())
-                .header(headerKey, token)
                 .contentType(MediaType.APPLICATION_JSON))
                                    .andDo(print());
 
@@ -152,7 +136,6 @@ public class MemberControllerTest {
         when(memberService.isDuplicatedMemberId(member.getMemberId())).thenReturn(true);
 
         ResultActions actions = mvc.perform(get("/members/validate/memberid/{memberId}", member.getMemberId())
-                .header(headerKey, token)
                 .contentType(MediaType.APPLICATION_JSON))
                                    .andDo(print());
 
@@ -168,7 +151,6 @@ public class MemberControllerTest {
         when(memberService.isDuplicatedNickName(member.getNickName())).thenReturn(false);
 
         ResultActions actions = mvc.perform(get("/members/validate/nickname/{nickName}", member.getNickName())
-                .header(headerKey, token)
                 .contentType(MediaType.APPLICATION_JSON))
                                    .andDo(print());
 
@@ -184,7 +166,6 @@ public class MemberControllerTest {
         when(memberService.isDuplicatedNickName(member.getNickName())).thenReturn(true);
 
         ResultActions actions = mvc.perform(get("/members/validate/nickname/{nickName}", member.getNickName())
-                .header(headerKey, token)
                 .contentType(MediaType.APPLICATION_JSON))
                                    .andDo(print());
 

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialControllerTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialControllerTest.java
@@ -1,12 +1,5 @@
 package com.sproutt.eussyaeussyaapi.api.oauth2;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.sproutt.eussyaeussyaapi.api.oauth2.exception.UnSupportedOAuth2Exception;
 import com.sproutt.eussyaeussyaapi.api.oauth2.service.OAuth2RequestService;
 import com.sproutt.eussyaeussyaapi.api.oauth2.service.SocialService;
@@ -23,6 +16,13 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(SocialController.class)
@@ -46,16 +46,16 @@ class SocialControllerTest {
         Member githubMember = MemberFactory.getGithubMember();
 
         when(oAuth2RequestService.getUserInfoByProvider(eq("token"), eq("github"), any()))
-            .thenReturn(githubMember);
+                .thenReturn(githubMember);
         when(socialService.login(githubMember)).thenReturn(githubMember);
-        when(jwtHelper.createToken(githubMember)).thenReturn("token");
+        when(jwtHelper.createToken(any(), any())).thenReturn("token");
 
         ResultActions actions = mockMvc.perform(post("/social/login/github")
-            .param("accessToken", "token")
-            .contentType(MediaType.APPLICATION_JSON)).andDo(print());
+                .param("accessToken", "token")
+                .contentType(MediaType.APPLICATION_JSON)).andDo(print());
 
         actions
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
     }
 
     @DisplayName("facebook으로 로그인")
@@ -64,16 +64,16 @@ class SocialControllerTest {
         Member githubMember = MemberFactory.getGithubMember();
 
         when(oAuth2RequestService.getUserInfoByProvider(eq("token"), eq("facebook"), any()))
-            .thenReturn(githubMember);
+                .thenReturn(githubMember);
         when(socialService.login(githubMember)).thenReturn(githubMember);
-        when(jwtHelper.createToken(githubMember)).thenReturn("token");
+        when(jwtHelper.createToken(any(), any())).thenReturn("token");
 
         ResultActions actions = mockMvc.perform(post("/social/login/facebook")
-            .param("accessToken", "token")
-            .contentType(MediaType.APPLICATION_JSON)).andDo(print());
+                .param("accessToken", "token")
+                .contentType(MediaType.APPLICATION_JSON)).andDo(print());
 
         actions
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
     }
 
     @DisplayName("google으로 로그인")
@@ -82,30 +82,30 @@ class SocialControllerTest {
         Member githubMember = MemberFactory.getGithubMember();
 
         when(oAuth2RequestService.getUserInfoByProvider(eq("token"), eq("google"), any()))
-            .thenReturn(githubMember);
+                .thenReturn(githubMember);
         when(socialService.login(githubMember)).thenReturn(githubMember);
-        when(jwtHelper.createToken(githubMember)).thenReturn("token");
+        when(jwtHelper.createToken(any(), any())).thenReturn("token");
 
         ResultActions actions = mockMvc.perform(post("/social/login/google")
-            .param("accessToken", "token")
-            .contentType(MediaType.APPLICATION_JSON)).andDo(print());
+                .param("accessToken", "token")
+                .contentType(MediaType.APPLICATION_JSON)).andDo(print());
 
         actions
-            .andExpect(status().isOk());
+                .andExpect(status().isOk());
     }
 
     @DisplayName("지원하지 않는 oauth2 로그인 시 UnSupportedException 발생")
     @Test
     public void login_by_no_provider() throws Exception {
         when(oAuth2RequestService.getUserInfoByProvider(eq("token"), eq("wrong"), any()))
-            .thenThrow(UnSupportedOAuth2Exception.class);
+                .thenThrow(UnSupportedOAuth2Exception.class);
 
         ResultActions actions = mockMvc.perform(post("/social/login/wrong")
-            .param("accessToken", "token")
-            .contentType(MediaType.APPLICATION_JSON)).andDo(print());
+                .param("accessToken", "token")
+                .contentType(MediaType.APPLICATION_JSON)).andDo(print());
 
         actions
-            .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest());
     }
 
 }

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/security/JwtHelperTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/security/JwtHelperTest.java
@@ -2,9 +2,11 @@ package com.sproutt.eussyaeussyaapi.api.security;
 
 import com.sproutt.eussyaeussyaapi.object.MemberFactory;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,16 +15,33 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(SpringExtension.class)
 class JwtHelperTest {
 
-    @Autowired
     private JwtHelper jwtHelper;
 
+    @BeforeEach
+    void setUp() {
+        jwtHelper = new JwtHelper();
+    }
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
     @Test
+    @DisplayName("토큰 생성이 잘 되는지 테스트")
     void create() {
 
-        String token = jwtHelper.createToken(MemberFactory.getDefaultMember().toJwtInfo());
+        String token = jwtHelper.createToken(secretKey, MemberFactory.getDefaultMember().toJwtInfo());
 
         log.info("token: ()", token);
 
         assertThat(token == null).isFalse();
+    }
+
+    @Test
+    @DisplayName("생성된 토큰 유효성 테스트")
+    void decrypt() {
+        String token = jwtHelper.createToken(secretKey, MemberFactory.getDefaultMember().toJwtInfo());
+
+        assertThat(jwtHelper.isUsable(secretKey, token)).isTrue();
+        assertThat(jwtHelper.decryptToken(secretKey, token).getNickName()).isEqualTo(MemberFactory.getDefaultMember().getNickName());
     }
 }

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/security/JwtHelperTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/security/JwtHelperTest.java
@@ -11,7 +11,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Slf4j
 @ExtendWith(SpringExtension.class)
 class JwtHelperTest {
 
@@ -28,10 +27,7 @@ class JwtHelperTest {
     @Test
     @DisplayName("토큰 생성이 잘 되는지 테스트")
     void create() {
-
         String token = jwtHelper.createToken(secretKey, MemberFactory.getDefaultMember().toJwtInfo());
-
-        log.info("token: ()", token);
 
         assertThat(token == null).isFalse();
     }

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/security/JwtHelperTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/security/JwtHelperTest.java
@@ -1,0 +1,28 @@
+package com.sproutt.eussyaeussyaapi.api.security;
+
+import com.sproutt.eussyaeussyaapi.object.MemberFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@ExtendWith(SpringExtension.class)
+class JwtHelperTest {
+
+    @Autowired
+    private JwtHelper jwtHelper;
+
+    @Test
+    void create() {
+
+        String token = jwtHelper.createToken(MemberFactory.getDefaultMember().toJwtInfo());
+
+        log.info("token: ()", token);
+
+        assertThat(token == null).isFalse();
+    }
+}


### PR DESCRIPTION
- jwt 인증이 되지 않으면 회원가입, 로그인 이후 서비스 접근 못하도록 interceptor 설정
- JwtHelper에서 사용하던 @Value로 받아오는 값을 컨트롤러에서 넘겨받도록 구현

token 정보
- header Key : Authorization
- 유효 기간 : 발급 후 1시간
- 토큰에 담긴 정보 : id, nickname
- 해싱에 사용되는 비밀키는 논의 후 더 복잡한 것으로 변경할 필요가 있음