### PR TITLE
[Back] 목표(데일리미션) api 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.2'
 
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/aspect/member/LoginMember.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/aspect/member/LoginMember.java
@@ -1,0 +1,11 @@
+package com.sproutt.eussyaeussyaapi.api.aspect.member;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginMember {
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/aspect/member/MemberAspect.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/aspect/member/MemberAspect.java
@@ -1,0 +1,46 @@
+package com.sproutt.eussyaeussyaapi.api.aspect.member;
+
+import com.sproutt.eussyaeussyaapi.api.member.dto.JwtMemberDTO;
+import com.sproutt.eussyaeussyaapi.api.security.JwtHelper;
+import com.sproutt.eussyaeussyaapi.application.member.MemberService;
+import com.sproutt.eussyaeussyaapi.domain.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Component
+@Aspect
+@RequiredArgsConstructor
+public class MemberAspect {
+
+    @Value("${jwt.header}")
+    private String tokenKey;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private final JwtHelper jwtHelper;
+    private final MemberService memberService;
+
+    @Around("execution(* *(.., @LoginMember (*), ..))")
+    public Object convertMember(ProceedingJoinPoint joinPoint) throws Throwable {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        String token = request.getHeader(tokenKey);
+        Member loginMember = getTokenOwner(token);
+
+        return joinPoint.proceed(new Object[] {loginMember});
+    }
+
+    private Member getTokenOwner(String token) {
+        JwtMemberDTO jwtMemberDTO = jwtHelper.decryptToken(secretKey, token);
+
+        return memberService.findTokenOwner(jwtMemberDTO);
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/aspect/member/MemberAspect.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/aspect/member/MemberAspect.java
@@ -2,8 +2,6 @@ package com.sproutt.eussyaeussyaapi.api.aspect.member;
 
 import com.sproutt.eussyaeussyaapi.api.member.dto.JwtMemberDTO;
 import com.sproutt.eussyaeussyaapi.api.security.JwtHelper;
-import com.sproutt.eussyaeussyaapi.application.member.MemberService;
-import com.sproutt.eussyaeussyaapi.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -27,20 +25,13 @@ public class MemberAspect {
     private String secretKey;
 
     private final JwtHelper jwtHelper;
-    private final MemberService memberService;
 
     @Around("execution(* *(.., @LoginMember (*), ..))")
     public Object convertMember(ProceedingJoinPoint joinPoint) throws Throwable {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
         String token = request.getHeader(tokenKey);
-        Member loginMember = getTokenOwner(token);
+        JwtMemberDTO loginMemberDTO = jwtHelper.decryptToken(secretKey, token);
 
-        return joinPoint.proceed(new Object[] {loginMember});
-    }
-
-    private Member getTokenOwner(String token) {
-        JwtMemberDTO jwtMemberDTO = jwtHelper.decryptToken(secretKey, token);
-
-        return memberService.findTokenOwner(jwtMemberDTO);
+        return joinPoint.proceed(new Object[] {loginMemberDTO});
     }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/aspect/mission/AvailableTime.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/aspect/mission/AvailableTime.java
@@ -1,0 +1,11 @@
+package com.sproutt.eussyaeussyaapi.api.aspect.mission;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AvailableTime {
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/aspect/mission/MissionAspect.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/aspect/mission/MissionAspect.java
@@ -1,0 +1,45 @@
+package com.sproutt.eussyaeussyaapi.api.aspect.mission;
+
+import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NotAvailableTimeException;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+@Component
+@Aspect
+public class MissionAspect {
+
+    private static final String ZONE_SEOUL = "Asia/Seoul";
+    private static final LocalTime START_AVAILABLE_LOCAL_TIME = LocalTime.of(4, 0);
+    private static final LocalTime END_AVAILABLE_LOCAL_TIME = LocalTime.of(9, 0);
+
+    @Before("@AvailableTime * (..)")
+    public void checkAvailableTime() {
+        System.out.println("걸렸네");
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        LocalTime now = changeEpochMilliToLocalTime(request.getDateHeader("date"));
+
+        if (!isAvailableTime(now)) {
+            System.out.println("걸렸어");
+            throw new NotAvailableTimeException();
+        }
+    }
+
+    private LocalTime changeEpochMilliToLocalTime(long epochMilli) {
+        Instant requestInstant = Instant.ofEpochMilli(epochMilli);
+
+        return requestInstant.atZone(ZoneId.of(ZONE_SEOUL)).toLocalTime();
+    }
+
+    private boolean isAvailableTime(LocalTime now) {
+        return now.isAfter(START_AVAILABLE_LOCAL_TIME) && now.isBefore(END_AVAILABLE_LOCAL_TIME);
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/aspect/mission/MissionAspect.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/aspect/mission/MissionAspect.java
@@ -20,15 +20,13 @@ public class MissionAspect {
     private static final LocalTime START_AVAILABLE_LOCAL_TIME = LocalTime.of(4, 0);
     private static final LocalTime END_AVAILABLE_LOCAL_TIME = LocalTime.of(9, 0);
 
-    @Before("@AvailableTime * (..)")
+    @Before("@annotation(AvailableTime)")
     public void checkAvailableTime() {
-        System.out.println("걸렸네");
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
 
         LocalTime now = changeEpochMilliToLocalTime(request.getDateHeader("date"));
 
         if (!isAvailableTime(now)) {
-            System.out.println("걸렸어");
             throw new NotAvailableTimeException();
         }
     }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/config/WebConfig.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/config/WebConfig.java
@@ -23,6 +23,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtInterceptor)
+                .addPathPatterns("/*")
                 .excludePathPatterns("/signUp", "/social/**", "/then/**", "/members/**", "/login", "/swagger-ui.html", "/webjars/**", "/swagger-resources/**", "/v2/**", "/email-auth", "/");
     }
 

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import com.sproutt.eussyaeussyaapi.domain.member.exceptions.WrongPasswordExcepti
 import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NoPermissionException;
 import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NoSuchMissionException;
 import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NotAvailableTimeException;
+import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NotSatisfiedCondition;
 import javassist.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -60,6 +61,13 @@ public class GlobalExceptionHandler {
         log.info("response: {}", response.toString());
 
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(value = NotSatisfiedCondition.class)
+    public ResponseEntity NotSatisfiedCondition(NotSatisfiedCondition exception) {
+        log.info("NotSatisfiedCondition : {}", exception);
+
+        return ResponseEntity.badRequest().contentType(MediaType.APPLICATION_JSON).body(exception.getMessage());
     }
 
     @ExceptionHandler(value = NoPermissionException.class)

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/exception/GlobalExceptionHandler.java
@@ -9,6 +9,9 @@ import com.sproutt.eussyaeussyaapi.domain.member.exceptions.DuplicationException
 import com.sproutt.eussyaeussyaapi.domain.member.exceptions.NoSuchMemberException;
 import com.sproutt.eussyaeussyaapi.domain.member.exceptions.VerificationException;
 import com.sproutt.eussyaeussyaapi.domain.member.exceptions.WrongPasswordException;
+import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NoPermissionException;
+import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NoSuchMissionException;
+import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NotAvailableTimeException;
 import javassist.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -59,11 +62,32 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(value = NoPermissionException.class)
+    public ResponseEntity NoPermissionException(NoPermissionException exception) {
+        log.info("NoPermissionException : {}", exception);
+
+        return ResponseEntity.badRequest().contentType(MediaType.APPLICATION_JSON).body(exception.getMessage());
+    }
+
+    @ExceptionHandler(value = NotAvailableTimeException.class)
+    public ResponseEntity notAvailableTimeException(NotAvailableTimeException exception) {
+        log.info("notAvailableTimeException : {}", exception);
+
+        return ResponseEntity.badRequest().contentType(MediaType.APPLICATION_JSON).body(exception.getMessage());
+    }
+
+    @ExceptionHandler(value = NoSuchMissionException.class)
+    public ResponseEntity noSuchMissionException(NoSuchMissionException exception) {
+        log.info("NoSuchMissionException : {}", exception);
+
+        return ResponseEntity.badRequest().contentType(MediaType.APPLICATION_JSON).body(exception.getMessage());
+    }
+
     @ExceptionHandler(value = InvalidTokenException.class)
     public ResponseEntity handleInvalidTokenException(InvalidTokenException exception) {
         log.info("handleInvalidTokenException : {}", exception);
 
-        return ResponseEntity.badRequest().contentType(MediaType.APPLICATION_JSON).body(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).contentType(MediaType.APPLICATION_JSON).body(exception.getMessage());
     }
 
     @ExceptionHandler(value = DuplicationException.class)

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
@@ -16,6 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.mail.MessagingException;
 import javax.validation.Valid;
 
 @Slf4j
@@ -38,7 +39,7 @@ public class MemberController {
     }
 
     @PostMapping("/members")
-    public ResponseEntity createMemberWithLocalProvider(@Valid @RequestBody JoinDTO joinDTO) {
+    public ResponseEntity createMemberWithLocalProvider(@Valid @RequestBody JoinDTO joinDTO) throws MessagingException {
 
         memberService.joinWithLocalProvider(joinDTO);
 
@@ -62,7 +63,7 @@ public class MemberController {
     }
 
     @PostMapping("/members/{memberId}/authcode")
-    public ResponseEntity sendAuthCodeEmail(@PathVariable String memberId) {
+    public ResponseEntity sendAuthCodeEmail(@PathVariable String memberId) throws MessagingException {
 
         memberService.sendAuthCodeToEmail(memberId);
 

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/mission/MissionController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/mission/MissionController.java
@@ -2,6 +2,7 @@ package com.sproutt.eussyaeussyaapi.api.mission;
 
 import com.sproutt.eussyaeussyaapi.api.aspect.member.LoginMember;
 import com.sproutt.eussyaeussyaapi.api.aspect.mission.AvailableTime;
+import com.sproutt.eussyaeussyaapi.api.member.dto.JwtMemberDTO;
 import com.sproutt.eussyaeussyaapi.api.mission.dto.MissionDTO;
 import com.sproutt.eussyaeussyaapi.application.member.MemberService;
 import com.sproutt.eussyaeussyaapi.application.mission.MissionService;
@@ -34,7 +35,8 @@ public class MissionController {
 
     @AvailableTime
     @PostMapping("/missions")
-    public ResponseEntity createMission(@LoginMember Member loginMember, @RequestBody @Valid MissionDTO missionDTO) {
+    public ResponseEntity createMission(@LoginMember JwtMemberDTO jwtMemberDTO, @RequestBody @Valid MissionDTO missionDTO) {
+        Member loginMember = memberService.findTokenOwner(jwtMemberDTO);
         missionService.create(loginMember, missionDTO);
 
         HttpHeaders headers = new HttpHeaders();
@@ -72,7 +74,8 @@ public class MissionController {
 
     @AvailableTime
     @PutMapping("/missions/{missionId}")
-    public ResponseEntity updateMission(@LoginMember Member loginMember, @PathVariable Long missionId, @RequestBody @Valid MissionDTO missionDTO) {
+    public ResponseEntity updateMission(@LoginMember JwtMemberDTO jwtMemberDTO, @PathVariable Long missionId, @RequestBody @Valid MissionDTO missionDTO) {
+        Member loginMember = memberService.findTokenOwner(jwtMemberDTO);
         missionService.update(loginMember, missionId, missionDTO);
 
         HttpHeaders headers = new HttpHeaders();
@@ -82,7 +85,8 @@ public class MissionController {
     }
 
     @DeleteMapping("/missions/{missionId}")
-    public ResponseEntity deleteMission(@LoginMember Member loginMember, @PathVariable Long missionId) {
+    public ResponseEntity deleteMission(@LoginMember JwtMemberDTO jwtMemberDTO, @PathVariable Long missionId) {
+        Member loginMember = memberService.findTokenOwner(jwtMemberDTO);
         missionService.delete(loginMember, missionId);
 
         HttpHeaders headers = new HttpHeaders();
@@ -93,8 +97,8 @@ public class MissionController {
 
     @AvailableTime
     @PutMapping("/missions/{missionId}/seconds")
-    public ResponseEntity addProcessTime(@RequestHeader HttpHeaders requestHeaders, @LoginMember Member loginMember, @PathVariable Long missionId, @RequestBody long processSeconds) {
-        LocalTime now = changeEpochMilliToLocalTime(requestHeaders.getDate());
+    public ResponseEntity addProcessTime(@LoginMember JwtMemberDTO jwtMemberDTO, @PathVariable Long missionId, @RequestBody long processSeconds) {
+        Member loginMember = memberService.findTokenOwner(jwtMemberDTO);
 
         missionService.passRunningTime(loginMember, missionId, processSeconds);
 
@@ -106,7 +110,8 @@ public class MissionController {
 
     @AvailableTime
     @PutMapping("/missions/{missionId}/progress")
-    public ResponseEntity startMission(@RequestHeader HttpHeaders requestHeaders, @LoginMember Member loginMember, @PathVariable Long missionId) {
+    public ResponseEntity startMission(@RequestHeader HttpHeaders requestHeaders, @LoginMember JwtMemberDTO jwtMemberDTO, @PathVariable Long missionId) {
+        Member loginMember = memberService.findTokenOwner(jwtMemberDTO);
         LocalTime now = changeEpochMilliToLocalTime(requestHeaders.getDate());
 
         missionService.changeStatus(loginMember, missionId, now, MissionStatus.IN_PROGRESS);
@@ -118,7 +123,8 @@ public class MissionController {
     }
 
     @PutMapping("/missions/{missionId}/complete")
-    public ResponseEntity completeMission(@RequestHeader HttpHeaders requestHeaders, @LoginMember Member loginMember, @PathVariable Long missionId) {
+    public ResponseEntity completeMission(@RequestHeader HttpHeaders requestHeaders, @LoginMember JwtMemberDTO jwtMemberDTO, @PathVariable Long missionId) {
+        Member loginMember = memberService.findTokenOwner(jwtMemberDTO);
         LocalTime now = changeEpochMilliToLocalTime(requestHeaders.getDate());
 
         missionService.changeStatus(loginMember, missionId, now, MissionStatus.COMPLETE);

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/mission/MissionController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/mission/MissionController.java
@@ -1,0 +1,131 @@
+package com.sproutt.eussyaeussyaapi.api.mission;
+
+import com.sproutt.eussyaeussyaapi.api.member.dto.JwtMemberDTO;
+import com.sproutt.eussyaeussyaapi.api.mission.dto.MissionDTO;
+import com.sproutt.eussyaeussyaapi.api.security.JwtHelper;
+import com.sproutt.eussyaeussyaapi.application.member.MemberService;
+import com.sproutt.eussyaeussyaapi.application.mission.MissionService;
+import com.sproutt.eussyaeussyaapi.domain.member.Member;
+import com.sproutt.eussyaeussyaapi.domain.mission.Mission;
+import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NotAvailableTimeException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+public class MissionController {
+
+    @Value("${jwt.header}")
+    private String tokenKey;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private static final LocalTime START_AVAILABLE_LOCAL_TIME = LocalTime.of(4, 0);
+    private static final LocalTime END_AVAILABLE_LOCAL_TIME = LocalTime.of(9, 0);
+
+    private final MemberService memberService;
+    private final MissionService missionService;
+    private final JwtHelper jwtHelper;
+
+    @PostMapping("/missions")
+    public ResponseEntity createMission(@RequestHeader HttpHeaders requestHeaders, @RequestBody @Valid MissionDTO missionDTO) {
+        String token = requestHeaders.get(tokenKey).get(0);
+        Member loginMember = getTokenOwner(token);
+
+        if (!isAvailableTime(requestHeaders.getDate())) {
+            throw new NotAvailableTimeException();
+        }
+
+        missionService.create(loginMember, missionDTO);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return new ResponseEntity<>(headers, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/missions/{missionId}")
+    public ResponseEntity<Mission> searchMission(@PathVariable Long missionId) {
+        Mission mission = missionService.findById(missionId);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return new ResponseEntity<>(mission, headers, HttpStatus.OK);
+    }
+
+    @GetMapping("/missions")
+    public ResponseEntity<List<Mission>> searchMissionList(@RequestParam(name = "writer", required = false) String memberId, @RequestParam(name = "after", required = false) String afterDate, @RequestParam(name = "before", required = false) String beforeDate) {
+        List<Mission> missionList;
+
+        if (memberId != null) {
+            Member writer = memberService.findByMemberId(memberId);
+            missionList = missionService.findByWriter(writer);
+        } else {
+            missionList = missionService.findAll();
+        }
+
+        missionList = missionService.filterDate(afterDate, beforeDate, missionList);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return new ResponseEntity<>(missionList, headers, HttpStatus.OK);
+    }
+
+    @PutMapping("/missions/{missionId}")
+    public ResponseEntity updateMission(@RequestHeader HttpHeaders requestHeaders, @PathVariable Long missionId, @RequestBody @Valid MissionDTO missionDTO) {
+        String token = requestHeaders.get(tokenKey).get(0);
+        Member loginMember = getTokenOwner(token);
+
+        if (!isAvailableTime(requestHeaders.getDate())) {
+            throw new NotAvailableTimeException();
+        }
+
+        missionService.update(loginMember, missionId, missionDTO);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return new ResponseEntity<>(headers, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/missions/{missionId}")
+    public ResponseEntity deleteMission(@RequestHeader HttpHeaders requestHeaders, @PathVariable Long missionId) {
+        String token = requestHeaders.get(tokenKey).get(0);
+        Member loginMember = getTokenOwner(token);
+
+        missionService.delete(loginMember, missionId);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return new ResponseEntity<>(headers, HttpStatus.OK);
+    }
+
+    private boolean isAvailableTime(long epochMilli) {
+        Instant requestInstant = Instant.ofEpochMilli(epochMilli);
+        LocalTime now = requestInstant.atZone(ZoneId.of("Asia/Seoul")).toLocalTime();
+
+        return now.isAfter(START_AVAILABLE_LOCAL_TIME) && now.isBefore(END_AVAILABLE_LOCAL_TIME);
+    }
+
+    private Member getTokenOwner(String token) {
+        JwtMemberDTO jwtMemberDTO = jwtHelper.decryptToken(secretKey, token);
+        return memberService.findTokenOwner(jwtMemberDTO);
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/mission/dto/MissionDTO.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/mission/dto/MissionDTO.java
@@ -1,0 +1,32 @@
+package com.sproutt.eussyaeussyaapi.api.mission.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MissionDTO {
+
+    @NotNull
+    @Size(max = 80)
+    private String title;
+
+    @NotNull
+    private String contents;
+
+    @NotNull
+    private int goalHours;
+
+    @Builder
+    public MissionDTO(@NotNull @Size(max = 80) String title, @NotNull String contents, @NotNull int goalHours) {
+        this.title = title;
+        this.contents = contents;
+        this.goalHours = goalHours;
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/mission/dto/MissionDTO.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/mission/dto/MissionDTO.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
 @Getter
@@ -13,20 +13,20 @@ import javax.validation.constraints.Size;
 @NoArgsConstructor
 public class MissionDTO {
 
-    @NotNull
+    @NotBlank
     @Size(max = 80)
     private String title;
 
-    @NotNull
+    @NotBlank
     private String contents;
 
-    @NotNull
-    private int goalHours;
+    @NotBlank
+    private String deadlineTime;
 
     @Builder
-    public MissionDTO(@NotNull @Size(max = 80) String title, @NotNull String contents, @NotNull int goalHours) {
+    public MissionDTO(String title, String contents, String deadlineTime) {
         this.title = title;
         this.contents = contents;
-        this.goalHours = goalHours;
+        this.deadlineTime = deadlineTime;
     }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/MailServiceImpl.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/MailServiceImpl.java
@@ -20,15 +20,16 @@ public class MailServiceImpl implements MailService {
     @Override
     public void sendAuthEmail(String email, String authCode) {
 
-        SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
+        SimpleMailMessage message = new SimpleMailMessage();
 
-        simpleMailMessage.setTo(email);
-        simpleMailMessage.setSubject("으쌰으쌰 계정 인증");
-        simpleMailMessage.setText("인증 코드: " + authCode);
+        message.setTo(email);
+        message.setSubject("으쌰으쌰 계정 인증");
+        message.setText("인증 코드: " + authCode);
 
         try {
-            mailSender.send(simpleMailMessage);
+            mailSender.send(message);
         } catch (Exception e) {
+            System.out.println(e.toString());
             throw new MailSendException("메일 전송 에러");
         }
     }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/member/MemberService.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/member/MemberService.java
@@ -2,8 +2,12 @@ package com.sproutt.eussyaeussyaapi.application.member;
 
 import com.sproutt.eussyaeussyaapi.api.member.EmailAuthDTO;
 import com.sproutt.eussyaeussyaapi.api.member.dto.JoinDTO;
+import com.sproutt.eussyaeussyaapi.api.member.dto.JwtMemberDTO;
 import com.sproutt.eussyaeussyaapi.api.member.dto.LoginDTO;
 import com.sproutt.eussyaeussyaapi.domain.member.Member;
+import com.sproutt.eussyaeussyaapi.domain.mission.Mission;
+
+import java.util.List;
 
 public interface MemberService {
 
@@ -17,7 +21,11 @@ public interface MemberService {
 
     Member sendAuthCodeToEmail(String email);
 
+    Member findTokenOwner(JwtMemberDTO jwtMemberDTO);
+
     boolean isDuplicatedMemberId(String memberId);
 
     boolean isDuplicatedNickName(String nickName);
+
+    Member findByMemberId(String memberId);
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/member/MemberService.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/member/MemberService.java
@@ -7,13 +7,14 @@ import com.sproutt.eussyaeussyaapi.api.member.dto.LoginDTO;
 import com.sproutt.eussyaeussyaapi.domain.member.Member;
 import com.sproutt.eussyaeussyaapi.domain.mission.Mission;
 
+import javax.mail.MessagingException;
 import java.util.List;
 
 public interface MemberService {
 
     Member login(LoginDTO loginDTO);
 
-    Member joinWithLocalProvider(JoinDTO joinDTO);
+    Member joinWithLocalProvider(JoinDTO joinDTO) throws MessagingException;
 
     Member joinWithOAuth2Provider();
 

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/member/MemberServiceImpl.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/member/MemberServiceImpl.java
@@ -2,6 +2,7 @@ package com.sproutt.eussyaeussyaapi.application.member;
 
 import com.sproutt.eussyaeussyaapi.api.member.EmailAuthDTO;
 import com.sproutt.eussyaeussyaapi.api.member.dto.JoinDTO;
+import com.sproutt.eussyaeussyaapi.api.member.dto.JwtMemberDTO;
 import com.sproutt.eussyaeussyaapi.api.member.dto.LoginDTO;
 import com.sproutt.eussyaeussyaapi.application.MailService;
 import com.sproutt.eussyaeussyaapi.domain.member.Member;
@@ -77,6 +78,11 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    public Member findTokenOwner(JwtMemberDTO jwtMemberDTO) {
+        return memberRepository.findById(jwtMemberDTO.getId()).orElseThrow(NoSuchMemberException::new);
+    }
+
+    @Override
     public boolean isDuplicatedMemberId(String memberId) {
 
         return memberRepository.findByMemberId(memberId).isPresent();
@@ -86,6 +92,12 @@ public class MemberServiceImpl implements MemberService {
     public boolean isDuplicatedNickName(String nickName) {
 
         return memberRepository.findByNickName(nickName).isPresent();
+    }
+
+    @Override
+    public Member findByMemberId(String memberId) {
+
+        return memberRepository.findByMemberId(memberId).orElseThrow(NoSuchMemberException::new);
     }
 
     @Override

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/member/MemberServiceImpl.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/member/MemberServiceImpl.java
@@ -17,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.mail.MessagingException;
+
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
@@ -38,7 +40,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public Member joinWithLocalProvider(JoinDTO joinDTO) {
+    public Member joinWithLocalProvider(JoinDTO joinDTO) throws MessagingException {
 
         if (memberRepository.findByMemberId(joinDTO.getMemberId()).orElse(null) != null) {
             throw new DuplicationMemberException();

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/mission/MissionService.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/mission/MissionService.java
@@ -20,4 +20,8 @@ public interface MissionService {
     List<Mission> findAll();
 
     List<Mission> filterDate(String afterDate, String beforeDate, List<Mission> missionList);
+
+    void completeMission(Member loginMember, Long missionId);
+
+    void addProcessTime(Member loginMember, Long missionId, long processSeconds);
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/mission/MissionService.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/mission/MissionService.java
@@ -3,6 +3,7 @@ package com.sproutt.eussyaeussyaapi.application.mission;
 import com.sproutt.eussyaeussyaapi.api.mission.dto.MissionDTO;
 import com.sproutt.eussyaeussyaapi.domain.member.Member;
 import com.sproutt.eussyaeussyaapi.domain.mission.Mission;
+import com.sproutt.eussyaeussyaapi.domain.mission.MissionStatus;
 
 import java.time.LocalTime;
 import java.util.List;
@@ -22,9 +23,7 @@ public interface MissionService {
 
     List<Mission> filterDate(String afterDate, String beforeDate, List<Mission> missionList);
 
-    void completeMission(Member loginMember, Long missionId, LocalTime now);
-
     void passRunningTime(Member loginMember, Long missionId, long processSeconds);
 
-    void startMission(Member loginMember, Long missionId, LocalTime now);
+    void changeStatus(Member loginMember, Long missionId, LocalTime now, MissionStatus status);
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/mission/MissionService.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/mission/MissionService.java
@@ -4,6 +4,7 @@ import com.sproutt.eussyaeussyaapi.api.mission.dto.MissionDTO;
 import com.sproutt.eussyaeussyaapi.domain.member.Member;
 import com.sproutt.eussyaeussyaapi.domain.mission.Mission;
 
+import java.time.LocalTime;
 import java.util.List;
 
 public interface MissionService {
@@ -21,7 +22,9 @@ public interface MissionService {
 
     List<Mission> filterDate(String afterDate, String beforeDate, List<Mission> missionList);
 
-    void completeMission(Member loginMember, Long missionId);
+    void completeMission(Member loginMember, Long missionId, LocalTime now);
 
-    void addProcessTime(Member loginMember, Long missionId, long processSeconds);
+    void passRunningTime(Member loginMember, Long missionId, long processSeconds);
+
+    void startMission(Member loginMember, Long missionId, LocalTime now);
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/mission/MissionService.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/mission/MissionService.java
@@ -1,0 +1,23 @@
+package com.sproutt.eussyaeussyaapi.application.mission;
+
+import com.sproutt.eussyaeussyaapi.api.mission.dto.MissionDTO;
+import com.sproutt.eussyaeussyaapi.domain.member.Member;
+import com.sproutt.eussyaeussyaapi.domain.mission.Mission;
+
+import java.util.List;
+
+public interface MissionService {
+    Mission create(Member loginMember, MissionDTO missionDTO);
+
+    Mission update(Member loginMember, Long missionId, MissionDTO missionDTO);
+
+    void delete(Member loginMember, Long missionId);
+
+    Mission findById(Long missionId);
+
+    List<Mission> findByWriter(Member byMemberId);
+
+    List<Mission> findAll();
+
+    List<Mission> filterDate(String afterDate, String beforeDate, List<Mission> missionList);
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/mission/MissionServiceImpl.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/mission/MissionServiceImpl.java
@@ -1,9 +1,11 @@
 package com.sproutt.eussyaeussyaapi.application.mission;
 
+import com.sproutt.eussyaeussyaapi.api.aspect.mission.AvailableTime;
 import com.sproutt.eussyaeussyaapi.api.mission.dto.MissionDTO;
 import com.sproutt.eussyaeussyaapi.domain.member.Member;
 import com.sproutt.eussyaeussyaapi.domain.mission.Mission;
 import com.sproutt.eussyaeussyaapi.domain.mission.MissionRepository;
+import com.sproutt.eussyaeussyaapi.domain.mission.MissionStatus;
 import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NoPermissionException;
 import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NoSuchMissionException;
 import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NotSatisfiedCondition;
@@ -85,22 +87,6 @@ public class MissionServiceImpl implements MissionService {
     }
 
     @Override
-    public void completeMission(Member loginMember, Long missionId, LocalTime now) {
-        Mission mission = missionRepository.findById(missionId).orElseThrow(NoSuchMissionException::new);
-
-        if (!mission.isWriter(loginMember)) {
-            throw new NoPermissionException();
-        }
-
-        if (!mission.isDeadlinePassed(now)) {
-            throw new NotSatisfiedCondition();
-        }
-
-        mission.complete();
-        missionRepository.save(mission);
-    }
-
-    @Override
     public void passRunningTime(Member loginMember, Long missionId, long runningSeconds) {
         Mission mission = missionRepository.findById(missionId).orElseThrow(NoSuchMissionException::new);
 
@@ -113,7 +99,7 @@ public class MissionServiceImpl implements MissionService {
     }
 
     @Override
-    public void startMission(Member loginMember, Long missionId, LocalTime now) {
+    public void changeStatus(Member loginMember, Long missionId, LocalTime now, MissionStatus status) {
         Mission mission = missionRepository.findById(missionId).orElseThrow(NoSuchMissionException::new);
 
         if (!mission.isWriter(loginMember)) {
@@ -124,7 +110,7 @@ public class MissionServiceImpl implements MissionService {
             throw new NotSatisfiedCondition();
         }
 
-        mission.start();
+        mission.changeStatus(status);
         missionRepository.save(mission);
     }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/mission/MissionServiceImpl.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/mission/MissionServiceImpl.java
@@ -6,6 +6,7 @@ import com.sproutt.eussyaeussyaapi.domain.mission.Mission;
 import com.sproutt.eussyaeussyaapi.domain.mission.MissionRepository;
 import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NoPermissionException;
 import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NoSuchMissionException;
+import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NotSatisfiedCondition;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -80,5 +81,33 @@ public class MissionServiceImpl implements MissionService {
         }
 
         return missionList;
+    }
+
+    @Override
+    public void completeMission(Member loginMember, Long missionId) {
+        Mission mission = missionRepository.findById(missionId).orElseThrow(NoSuchMissionException::new);
+
+        if (!mission.isSameWriter(loginMember)) {
+            throw new NoPermissionException();
+        }
+
+        if (!mission.isSatisfiedWithGoalTime()) {
+            throw new NotSatisfiedCondition();
+        }
+
+        mission.complete();
+        missionRepository.save(mission);
+    }
+
+    @Override
+    public void addProcessTime(Member loginMember, Long missionId, long processSeconds) {
+        Mission mission = missionRepository.findById(missionId).orElseThrow(NoSuchMissionException::new);
+
+        if (!mission.isSameWriter(loginMember)) {
+            throw new NoPermissionException();
+        }
+
+        mission.addProcessTime(processSeconds);
+        missionRepository.save(mission);
     }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/mission/MissionServiceImpl.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/mission/MissionServiceImpl.java
@@ -1,0 +1,84 @@
+package com.sproutt.eussyaeussyaapi.application.mission;
+
+import com.sproutt.eussyaeussyaapi.api.mission.dto.MissionDTO;
+import com.sproutt.eussyaeussyaapi.domain.member.Member;
+import com.sproutt.eussyaeussyaapi.domain.mission.Mission;
+import com.sproutt.eussyaeussyaapi.domain.mission.MissionRepository;
+import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NoPermissionException;
+import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NoSuchMissionException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MissionServiceImpl implements MissionService {
+
+    private final MissionRepository missionRepository;
+
+    @Override
+    public Mission create(Member loginMember, MissionDTO missionDTO) {
+        Mission mission = new Mission(loginMember, missionDTO);
+
+        return missionRepository.save(mission);
+    }
+
+    @Override
+    public Mission update(Member loginMember, Long missionId, MissionDTO missionDTO) {
+        Mission mission = missionRepository.findById(missionId).orElseThrow(NoSuchMissionException::new);
+
+        if (!mission.isSameWriter(loginMember)) {
+            throw new RuntimeException();
+        }
+
+        return missionRepository.save(mission.update(missionDTO));
+    }
+
+    @Override
+    public void delete(Member loginMember, Long missionId) {
+        Mission mission = missionRepository.findById(missionId).orElseThrow(NoSuchMissionException::new);
+
+        if (!mission.isSameWriter(loginMember)) {
+            throw new NoPermissionException();
+        }
+
+        missionRepository.delete(mission);
+    }
+
+    @Override
+    public Mission findById(Long missionId) {
+        return missionRepository.findById(missionId).orElseThrow(NoSuchMissionException::new);
+    }
+
+    @Override
+    public List<Mission> findByWriter(Member writer) {
+        return missionRepository.findAllByWriter(writer);
+    }
+
+    @Override
+    public List<Mission> findAll() {
+        return missionRepository.findAll();
+    }
+
+    @Override
+    public List<Mission> filterDate(String afterDate, String beforeDate, List<Mission> missionList) {
+        if (afterDate != null) {
+            LocalDateTime afterLocalDateTime = LocalDateTime.parse(afterDate);
+            missionList = missionList.stream()
+                                     .filter(mission -> mission.getCreatedTime().isAfter(afterLocalDateTime))
+                                     .collect(Collectors.toList());
+        }
+
+        if (beforeDate != null) {
+            LocalDateTime beforeLocalDateTime = LocalDateTime.parse(beforeDate);
+            missionList = missionList.stream()
+                                     .filter(mission -> mission.getCreatedTime().isBefore(beforeLocalDateTime))
+                                     .collect(Collectors.toList());
+        }
+
+        return missionList;
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/member/Member.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/member/Member.java
@@ -1,12 +1,16 @@
 package com.sproutt.eussyaeussyaapi.domain.member;
 
 import com.sproutt.eussyaeussyaapi.api.member.dto.JwtMemberDTO;
+import com.sproutt.eussyaeussyaapi.domain.mission.Mission;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import javax.validation.constraints.Email;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -37,6 +41,9 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private Provider provider;
 
+    @OneToMany(mappedBy = "writer", cascade = CascadeType.ALL)
+    private List<Mission> missions = new ArrayList<>();
+
 
     @Builder
     public Member(String memberId, String password, String email, String nickName, String authentication, Provider provider) {
@@ -46,10 +53,6 @@ public class Member {
         this.nickName = nickName;
         this.authentication = authentication;
         this.provider = provider;
-    }
-
-    public boolean isEqualId(String memberId) {
-        return this.memberId.equals(memberId);
     }
 
     public boolean isEqualPassword(String password) {
@@ -76,5 +79,13 @@ public class Member {
                 .id(this.id)
                 .nickName(this.nickName)
                 .build();
+    }
+
+    public void addMission(Mission mission) {
+        missions.add(mission);
+    }
+
+    public boolean isSameMember(Member member) {
+        return this.getId().equals(member.getId());
     }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/member/Member.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/member/Member.java
@@ -85,7 +85,7 @@ public class Member {
         missions.add(mission);
     }
 
-    public boolean isSameMember(Member member) {
-        return this.getId().equals(member.getId());
+    public boolean isSame(Member member) {
+        return this == member;
     }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/Mission.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/Mission.java
@@ -21,9 +21,10 @@ public class Mission {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 80)
     private String title;
 
+    @Lob
     @Column(nullable = false)
     private String contents;
 
@@ -44,7 +45,7 @@ public class Mission {
     private LocalTime runningTime = LocalTime.of(0, 0);
 
     @Column
-    private MissionStatus status = MissionStatus.BEFORE_START;
+    private MissionStatus status = MissionStatus.PENDING;
 
     @Builder
     public Mission(String title, String contents, Member writer, LocalTime deadlineTime) {
@@ -87,5 +88,9 @@ public class Mission {
 
     public void start() {
         this.status = MissionStatus.IN_PROGRESS;
+    }
+
+    public void changeStatus(MissionStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/Mission.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/Mission.java
@@ -1,0 +1,93 @@
+package com.sproutt.eussyaeussyaapi.domain.mission;
+
+import com.sproutt.eussyaeussyaapi.api.mission.dto.MissionDTO;
+import com.sproutt.eussyaeussyaapi.domain.member.Member;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Mission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String contents;
+
+    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, foreignKey = @ForeignKey(name = "fk_mission_writer"))
+    private Member writer;
+
+    @CreatedDate
+    private LocalDateTime createdTime;
+
+    @LastModifiedDate
+    private LocalDateTime updatedTime;
+
+    @Column
+    private int goalSeconds;
+
+    @Column
+    private int progressSeconds = 0;
+
+    @Column
+    private boolean achievement = false;
+
+    @Builder
+    public Mission(String title, String contents, Member writer, int goalSeconds) {
+        this.title = title;
+        this.contents = contents;
+        this.writer = writer;
+        this.goalSeconds = goalSeconds;
+    }
+
+    public Mission(Member writer, MissionDTO missionDTO) {
+        this.title = missionDTO.getTitle();
+        this.contents = missionDTO.getContents();
+        this.goalSeconds = changeHoursToSeconds(missionDTO.getGoalHours());
+        this.writer = writer;
+    }
+
+    private int changeHoursToSeconds(int goalHours) {
+        return goalHours * 60 * 60;
+    }
+
+    @Override
+    public String toString() {
+        return "Mission{" +
+                "id=" + id +
+                ", title='" + title + '\'' +
+                ", contents='" + contents + '\'' +
+                ", writer=" + writer +
+                ", createdTime=" + createdTime +
+                ", updatedTime=" + updatedTime +
+                ", goalSeconds=" + goalSeconds +
+                ", progressSeconds=" + progressSeconds +
+                ", achievement=" + achievement +
+                '}';
+    }
+
+    public boolean isSameWriter(Member member) {
+        return this.writer.isSameMember(member);
+    }
+
+    public Mission update(MissionDTO missionDTO) {
+        this.title = missionDTO.getTitle();
+        this.contents = missionDTO.getContents();
+        this.goalSeconds = changeHoursToSeconds(missionDTO.getGoalHours());
+
+        return this;
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/Mission.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/Mission.java
@@ -90,4 +90,16 @@ public class Mission {
 
         return this;
     }
+
+    public boolean isSatisfiedWithGoalTime() {
+        return this.progressSeconds >= this.goalSeconds;
+    }
+
+    public void addProcessTime(long runningSeconds) {
+        this.progressSeconds += runningSeconds;
+    }
+
+    public void complete() {
+        this.achievement = true;
+    }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/MissionRepository.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/MissionRepository.java
@@ -1,0 +1,12 @@
+package com.sproutt.eussyaeussyaapi.domain.mission;
+
+import com.sproutt.eussyaeussyaapi.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+    List<Mission> findAllByWriter(Member writer);
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/MissionStatus.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/MissionStatus.java
@@ -1,7 +1,7 @@
 package com.sproutt.eussyaeussyaapi.domain.mission;
 
 public enum MissionStatus {
-    BEFORE_START,
+    PENDING,
     IN_PROGRESS,
     COMPLETE
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/MissionStatus.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/MissionStatus.java
@@ -1,0 +1,7 @@
+package com.sproutt.eussyaeussyaapi.domain.mission;
+
+public enum MissionStatus {
+    BEFORE_START,
+    IN_PROGRESS,
+    COMPLETE
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/exceptions/NoPermissionException.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/exceptions/NoPermissionException.java
@@ -1,0 +1,9 @@
+package com.sproutt.eussyaeussyaapi.domain.mission.exceptions;
+
+import com.sproutt.eussyaeussyaapi.utils.ExceptionMessage;
+
+public class NoPermissionException extends RuntimeException {
+    public NoPermissionException() {
+        super(ExceptionMessage.No_PERMISSION);
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/exceptions/NoPermissionException.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/exceptions/NoPermissionException.java
@@ -4,6 +4,6 @@ import com.sproutt.eussyaeussyaapi.utils.ExceptionMessage;
 
 public class NoPermissionException extends RuntimeException {
     public NoPermissionException() {
-        super(ExceptionMessage.No_PERMISSION);
+        super(ExceptionMessage.NO_PERMISSION);
     }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/exceptions/NoSuchMissionException.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/exceptions/NoSuchMissionException.java
@@ -1,0 +1,9 @@
+package com.sproutt.eussyaeussyaapi.domain.mission.exceptions;
+
+import com.sproutt.eussyaeussyaapi.utils.ExceptionMessage;
+
+public class NoSuchMissionException extends RuntimeException {
+    public NoSuchMissionException() {
+        super(ExceptionMessage.NO_SUCH_MISSION);
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/exceptions/NotAvailableTimeException.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/exceptions/NotAvailableTimeException.java
@@ -1,0 +1,10 @@
+package com.sproutt.eussyaeussyaapi.domain.mission.exceptions;
+
+
+import com.sproutt.eussyaeussyaapi.utils.ExceptionMessage;
+
+public class NotAvailableTimeException extends RuntimeException {
+    public NotAvailableTimeException() {
+        super(ExceptionMessage.NOT_AVAILABLE_TIME);
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/exceptions/NotSatisfiedCondition.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/exceptions/NotSatisfiedCondition.java
@@ -1,0 +1,9 @@
+package com.sproutt.eussyaeussyaapi.domain.mission.exceptions;
+
+import com.sproutt.eussyaeussyaapi.utils.ExceptionMessage;
+
+public class NotSatisfiedCondition extends RuntimeException {
+    public NotSatisfiedCondition() {
+        super(ExceptionMessage.NOT_SATISFIED_CONDITION);
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/utils/ExceptionMessage.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/utils/ExceptionMessage.java
@@ -12,6 +12,6 @@ public class ExceptionMessage {
     public static final String INVALID_TOKEN = "유효하지 않은 토큰";
     public static final String NOT_AVAILABLE_TIME = "서비스 시간이 아닙니다.";
     public static final String NO_SUCH_MISSION = "존재하지 않는 미션입니다.";
-    public static final String No_PERMISSION = "권한 없음";
+    public static final String NO_PERMISSION = "권한 없음";
     public static final String NOT_SATISFIED_CONDITION = "목표 시간을 채우지 못했습니다.";
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/utils/ExceptionMessage.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/utils/ExceptionMessage.java
@@ -13,4 +13,5 @@ public class ExceptionMessage {
     public static final String NOT_AVAILABLE_TIME = "서비스 시간이 아닙니다.";
     public static final String NO_SUCH_MISSION = "존재하지 않는 미션입니다.";
     public static final String No_PERMISSION = "권한 없음";
+    public static final String NOT_SATISFIED_CONDITION = "목표 시간을 채우지 못했습니다.";
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/utils/ExceptionMessage.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/utils/ExceptionMessage.java
@@ -10,4 +10,7 @@ public class ExceptionMessage {
     public static final String UNSUPPORT_OAUTH = "지원하지 않거나 존재하지 않는 oauth 입니다.";
     public static final String FAILED_VERIFICATION = "인증 실패";
     public static final String INVALID_TOKEN = "유효하지 않은 토큰";
+    public static final String NOT_AVAILABLE_TIME = "서비스 시간이 아닙니다.";
+    public static final String NO_SUCH_MISSION = "존재하지 않는 미션입니다.";
+    public static final String No_PERMISSION = "권한 없음";
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
     default-encoding: UTF-8
     protocol: smtp
     username: ENC(9NlYFfJbK5Epx/lOVqJGRvbtU5BWSytOZx8qNOgf1tE=)
-    password: ENC(wHLmmtZ0B/Y5Zqi78lHAcwIC7nV7OCGw)
+    password: ENC(QM4Aq26vJvLXQcvIBRlP5UUOkE33ZB0P)
     properties:
       mail:
         smtp:

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/HeaderSetUpWithToken.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/HeaderSetUpWithToken.java
@@ -4,13 +4,14 @@ import com.sproutt.eussyaeussyaapi.api.security.JwtHelper;
 import com.sproutt.eussyaeussyaapi.api.security.JwtInterceptor;
 import com.sproutt.eussyaeussyaapi.domain.member.Member;
 import com.sproutt.eussyaeussyaapi.object.MemberFactory;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.ZonedDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -38,8 +39,10 @@ public class HeaderSetUpWithToken {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set(tokenKey, token);
+        headers.setZonedDateTime("date", ZonedDateTime.now());
 
         when(jwtInterceptor.preHandle(any(), any(), any())).thenReturn(true);
+        when(jwtHelper.decryptToken(secretKey, token)).thenReturn(loginMember.toJwtInfo());
 
         return headers;
     }

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/mission/MissionControllerTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/mission/MissionControllerTest.java
@@ -1,0 +1,333 @@
+package com.sproutt.eussyaeussyaapi.api.mission;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sproutt.eussyaeussyaapi.api.HeaderSetUpWithToken;
+import com.sproutt.eussyaeussyaapi.api.mission.dto.MissionDTO;
+import com.sproutt.eussyaeussyaapi.application.member.MemberService;
+import com.sproutt.eussyaeussyaapi.application.mission.MissionService;
+import com.sproutt.eussyaeussyaapi.domain.member.Member;
+import com.sproutt.eussyaeussyaapi.domain.mission.Mission;
+import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NoPermissionException;
+import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NotAvailableTimeException;
+import com.sproutt.eussyaeussyaapi.object.MemberFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(MissionController.class)
+public class MissionControllerTest extends HeaderSetUpWithToken {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private MissionService missionService;
+
+    @MockBean
+    private MemberService memberService;
+
+    private HttpHeaders headers;
+    private Member loginMember;
+    private List<Mission> missionsList;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        headers = setUpHeader();
+        loginMember = MemberFactory.getDefaultMember();
+        missionsList = setMockMissionList();
+    }
+
+    @Test
+    @DisplayName("미션 등록 요청 - 정상적인 경우")
+    void createMissionTest() throws Exception {
+        headers.setZonedDateTime("date", ZonedDateTime.of(2020, 7, 4, 5, 0, 0, 0, ZoneId.of("Asia/Seoul")));
+
+        MissionDTO missionDTO = new MissionDTO()
+                .builder()
+                .title("test_title")
+                .contents("test_contents")
+                .goalHours(2)
+                .build();
+
+        Mission mission = new Mission(loginMember, missionDTO);
+
+        given(memberService.findTokenOwner(any())).willReturn(loginMember);
+        given(missionService.create(any(), any())).willReturn(mission);
+
+        ResultActions actions = mvc.perform(post("/missions")
+                .headers(headers)
+                .characterEncoding("utf-8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(missionDTO)))
+                                   .andDo(print());
+
+        actions.andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("미션 등록 요청 - 입력이 잘못된 경우")
+    void createMissionTest_withWrongInput() throws Exception {
+        MissionDTO wrongMissionDTO = new MissionDTO();
+
+        Mission mission = new Mission(loginMember, wrongMissionDTO);
+
+        given(missionService.create(loginMember, wrongMissionDTO)).willReturn(mission);
+
+        ResultActions actions = mvc.perform(post("/missions")
+                .headers(headers)
+                .characterEncoding("utf-8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(wrongMissionDTO)))
+                                   .andDo(print());
+
+        actions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("미션 등록 요청 - 등록 가능 시간이 아닌 경우")
+    void createMissionTest_withWrongTime() throws Exception {
+        headers.setZonedDateTime("date", ZonedDateTime.of(2020, 7, 4, 10, 0, 0, 0, ZoneId.of("Asia/Seoul")));
+
+        MissionDTO missionDTO = new MissionDTO()
+                .builder()
+                .title("test_title")
+                .contents("test_contents")
+                .goalHours(2)
+                .build();
+
+        given(missionService.create(loginMember, missionDTO)).willThrow(new NotAvailableTimeException());
+
+        ResultActions actions = mvc.perform(post("/missions")
+                .headers(headers)
+                .characterEncoding("utf-8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(missionDTO)))
+                                   .andDo(print());
+
+        actions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("미션 조회 요청")
+    void readMissionTest_withDate() throws Exception {
+        given(missionService.findByWriter(any())).willReturn(missionsList);
+
+        ResultActions actions = mvc.perform(get("/missions")
+                .headers(headers)
+                .characterEncoding("utf-8")
+                .contentType(MediaType.APPLICATION_JSON))
+                                   .andDo(print());
+
+        actions.andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("미션 수정 요청 - 정상적인 경우")
+    void updateMissionTest() throws Exception {
+        headers.setZonedDateTime("date", ZonedDateTime.of(2020, 7, 4, 5, 0, 0, 0, ZoneId.of("Asia/Seoul")));
+
+        MissionDTO missionDTO = new MissionDTO()
+                .builder()
+                .title("test_title")
+                .contents("test_contents")
+                .goalHours(2)
+                .build();
+
+        MissionDTO updatedMissionDTO = MissionDTO
+                .builder()
+                .title("update")
+                .contents("update_contents")
+                .goalHours(2)
+                .build();
+
+        Mission mission = new Mission(loginMember, missionDTO);
+        Mission updatedMission = new Mission(loginMember, updatedMissionDTO);
+
+        given(missionService.findById(0l)).willReturn(mission);
+        given(missionService.update(loginMember, 0l, updatedMissionDTO)).willReturn(updatedMission);
+
+        ResultActions actions = mvc.perform(put("/missions/0")
+                .headers(headers)
+                .characterEncoding("utf-8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(updatedMissionDTO)))
+                                   .andDo(print());
+
+        actions.andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("미션 수정 요청 - 입력이 잘못된 경우")
+    void updateMissionTest_withWrongInput() throws Exception {
+        headers.setZonedDateTime("date", ZonedDateTime.of(2020, 7, 4, 5, 0, 0, 0, ZoneId.of("Asia/Seoul")));
+
+        MissionDTO missionDTO = new MissionDTO()
+                .builder()
+                .title("test_title")
+                .contents("test_contents")
+                .goalHours(2)
+                .build();
+
+        MissionDTO wrongUpdatedMissionDTO = new MissionDTO();
+
+        Mission mission = new Mission(loginMember, missionDTO);
+        Mission updatedMission = new Mission(loginMember, wrongUpdatedMissionDTO);
+
+        given(missionService.findById(0l)).willReturn(mission);
+        given(missionService.update(loginMember, 0l, wrongUpdatedMissionDTO)).willReturn(updatedMission);
+
+        ResultActions actions = mvc.perform(put("/missions/0")
+                .headers(headers)
+                .characterEncoding("utf-8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(wrongUpdatedMissionDTO)))
+                                   .andDo(print());
+
+        actions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("미션 수정 요청 - 수정 가능 시간이 아닌 경우")
+    void updateMissionTest_withWrongTime() throws Exception {
+        headers.setZonedDateTime("date", ZonedDateTime.of(2020, 7, 4, 10, 0, 0, 0, ZoneId.of("Asia/Seoul")));
+
+        MissionDTO missionDTO = new MissionDTO()
+                .builder()
+                .title("test_title")
+                .contents("test_contents")
+                .goalHours(2)
+                .build();
+
+        MissionDTO updatedMissionDTO = MissionDTO
+                .builder()
+                .title("update")
+                .contents("update_contents")
+                .goalHours(2)
+                .build();
+
+        Mission mission = new Mission(loginMember, missionDTO);
+        Mission updatedMission = new Mission(loginMember, updatedMissionDTO);
+
+        given(missionService.findById(0l)).willReturn(mission);
+        given(missionService.update(loginMember, 0l, updatedMissionDTO)).willReturn(updatedMission);
+
+        ResultActions actions = mvc.perform(put("/missions/0")
+                .headers(headers)
+                .characterEncoding("utf-8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJsonString(updatedMissionDTO)))
+                                   .andDo(print());
+
+        actions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("미션 삭제 요청 - 정상적인 경우")
+    void deleteMissionTest() throws Exception {
+        MissionDTO missionDTO = new MissionDTO()
+                .builder()
+                .title("test_title")
+                .contents("test_contents")
+                .goalHours(2)
+                .build();
+
+        Mission mission = new Mission(loginMember, missionDTO);
+
+        ResultActions actions = mvc.perform(delete("/missions/0")
+                .headers(headers)
+                .characterEncoding("utf-8")
+                .contentType(MediaType.APPLICATION_JSON))
+                                   .andDo(print());
+
+        actions.andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("미션 삭제 요청 - 작성자와 일치하지 않는 경우")
+    void deleteMissionTest_WithWrongWriter() throws Exception {
+        doThrow(new NoPermissionException()).when(missionService).delete(any(), any());
+
+        ResultActions actions = mvc.perform(delete("/missions/0")
+                .headers(headers)
+                .characterEncoding("utf-8")
+                .contentType(MediaType.APPLICATION_JSON))
+                                   .andDo(print());
+
+        actions.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("미션 달성 요청 - 정상적인 경우")
+    void setAchieveMissionTest() {
+    }
+
+    @Test
+    @DisplayName("미션 달성 요청 - 달성 가능 시간이 아닌 경우")
+    void setAchieveMissionTest_withWrongTime() {
+    }
+
+    @Test
+    @DisplayName("미션 달성 요청 - 목표 시간을 채우지 못한 경우")
+    void setAchieveMissionTest_withWrongProgressTime() {
+    }
+
+    private static String asJsonString(final Object object) {
+        try {
+            return new ObjectMapper().writeValueAsString(object);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<Mission> setMockMissionList() {
+        Mission mission1 = Mission.builder()
+                                  .title("test1")
+                                  .contents("test_contents")
+                                  .goalSeconds(2)
+                                  .writer(loginMember)
+                                  .build();
+
+        Mission mission2 = Mission.builder()
+                                  .title("test2")
+                                  .contents("test_contents")
+                                  .goalSeconds(2)
+                                  .writer(loginMember)
+                                  .build();
+
+        Mission mission3 = Mission.builder()
+                                  .title("test3")
+                                  .contents("test_contents")
+                                  .goalSeconds(2)
+                                  .writer(new Member())
+                                  .build();
+
+        List<Mission> mockedMissionsList = new ArrayList<>();
+        mockedMissionsList.add(mission1);
+        mockedMissionsList.add(mission2);
+        mockedMissionsList.add(mission3);
+
+        return mockedMissionsList;
+    }
+}

--- a/src/test/java/com/sproutt/eussyaeussyaapi/application/MissionServiceTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/application/MissionServiceTest.java
@@ -65,7 +65,7 @@ public class MissionServiceTest {
                                  .writer(loginMember)
                                  .build();
 
-        when(missionRepository.findById(any(Long.class))).thenReturn(Optional.of(mission));
+        when(missionRepository.findById(any())).thenReturn(Optional.of(mission));
 
         Mission searchedMission = missionService.findById(mission.getId());
 

--- a/src/test/java/com/sproutt/eussyaeussyaapi/application/MissionServiceTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/application/MissionServiceTest.java
@@ -158,7 +158,7 @@ public class MissionServiceTest {
         Mission mission = new Mission(loginMember, missionDTO);
 
         when(missionRepository.findById(any())).thenReturn(Optional.of(mission));
-        missionService.startMission(loginMember, 0l, LocalTime.of(9, 1));
+        missionService.changeStatus(loginMember, 0l, LocalTime.of(9, 1), MissionStatus.IN_PROGRESS);
 
         assertEquals(MissionStatus.IN_PROGRESS, missionService.findById(0l).getStatus());
     }
@@ -176,7 +176,7 @@ public class MissionServiceTest {
         Mission mission = new Mission(loginMember, missionDTO);
 
         when(missionRepository.findById(any())).thenReturn(Optional.of(mission));
-        missionService.completeMission(loginMember, 0l, LocalTime.of(9, 1));
+        missionService.changeStatus(loginMember, 0l, LocalTime.of(9, 1), MissionStatus.COMPLETE);
 
         assertEquals(MissionStatus.COMPLETE, missionService.findById(0l).getStatus());
     }

--- a/src/test/java/com/sproutt/eussyaeussyaapi/application/MissionServiceTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/application/MissionServiceTest.java
@@ -6,6 +6,8 @@ import com.sproutt.eussyaeussyaapi.application.mission.MissionServiceImpl;
 import com.sproutt.eussyaeussyaapi.domain.member.Member;
 import com.sproutt.eussyaeussyaapi.domain.mission.Mission;
 import com.sproutt.eussyaeussyaapi.domain.mission.MissionRepository;
+import com.sproutt.eussyaeussyaapi.domain.mission.MissionStatus;
+import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NoSuchMissionException;
 import com.sproutt.eussyaeussyaapi.object.MemberFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -13,12 +15,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -44,7 +48,7 @@ public class MissionServiceTest {
                 .builder()
                 .title("test_title")
                 .contents("test_contents")
-                .goalHours(2)
+                .deadlineTime("09:00:00")
                 .build();
 
         Mission mission = new Mission(loginMember, missionDTO);
@@ -61,7 +65,7 @@ public class MissionServiceTest {
         Mission mission = Mission.builder()
                                  .title("test")
                                  .contents("test_contents")
-                                 .goalSeconds(2)
+                                 .deadlineTime(LocalTime.of(9, 0))
                                  .writer(loginMember)
                                  .build();
 
@@ -98,85 +102,104 @@ public class MissionServiceTest {
     @Test
     @DisplayName("미션 수정 테스트")
     void updateMission() {
-//        MissionDTO missionDTO = MissionDTO
-//                .builder()
-//                .title("test_title")
-//                .contents("test_contents")
-//                .goalHours(2)
-//                .build();
-//
-//        Mission mission = new Mission(loginMember, missionDTO);
-//
-//        MissionDTO updatedMissionDTO = MissionDTO
-//                .builder()
-//                .title("test_title2")
-//                .contents("test_contents2")
-//                .goalHours(3)
-//                .build();
-//
-//        when(missionRepository.findById(0l)).thenReturn(Optional.of(mission));
-//        when(missionRepository.save(any())).thenReturn(new Mission(loginMember, updatedMissionDTO));
-//
-//        Mission updatedMission = missionService.update(loginMember, 0l, missionDTO);
-//
-//        assertEquals(updatedMissionDTO.getTitle(), updatedMission.getTitle());
+        MissionDTO missionDTO = MissionDTO
+                .builder()
+                .title("test_title")
+                .contents("test_contents")
+                .deadlineTime("09:00:00")
+                .build();
+
+        Mission mission = new Mission(loginMember, missionDTO);
+
+        MissionDTO updatedMissionDTO = MissionDTO
+                .builder()
+                .title("test_title2")
+                .contents("test_contents2")
+                .deadlineTime("09:00:00")
+                .build();
+
+        when(missionRepository.findById(0l)).thenReturn(Optional.of(mission));
+        when(missionRepository.save(any())).thenReturn(new Mission(loginMember, updatedMissionDTO));
+
+        Mission updatedMission = missionService.update(loginMember, 0l, missionDTO);
+
+        assertEquals(updatedMissionDTO.getTitle(), updatedMission.getTitle());
     }
 
     @Test
     @DisplayName("미션 삭제 테스트")
     void deleteMission() {
-//        MissionDTO missionDTO = MissionDTO
-//                .builder()
-//                .title("test_title")
-//                .contents("test_contents")
-//                .goalHours(2)
-//                .build();
-//
-//        Mission mission = new Mission(loginMember, missionDTO);
-//
-//        when(missionRepository.findById(0l)).thenReturn(Optional.of(mission));
-//        missionService.delete(loginMember, 0l);
-//
-//        assertThrows(NoSuchMissionException.class,() -> missionService.findById(0l));
+        MissionDTO missionDTO = MissionDTO
+                .builder()
+                .title("test_title")
+                .contents("test_contents")
+                .deadlineTime("09:00:00")
+                .build();
+
+        Mission mission = new Mission(loginMember, missionDTO);
+
+        when(missionRepository.findById(0l)).thenReturn(Optional.of(mission));
+        missionService.delete(loginMember, 0l);
+        when(missionRepository.findById(0l)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchMissionException.class, () -> missionService.findById(0l));
+    }
+
+    @Test
+    @DisplayName("미션 시작 테스트")
+    void startMission() {
+        MissionDTO missionDTO = MissionDTO
+                .builder()
+                .title("test_title")
+                .contents("test_contents")
+                .deadlineTime("09:00:00")
+                .build();
+
+        Mission mission = new Mission(loginMember, missionDTO);
+
+        when(missionRepository.findById(any())).thenReturn(Optional.of(mission));
+        missionService.startMission(loginMember, 0l, LocalTime.of(9, 1));
+
+        assertEquals(MissionStatus.IN_PROGRESS, missionService.findById(0l).getStatus());
     }
 
     @Test
     @DisplayName("미션 완료 테스트")
     void completeMission() {
-//        MissionDTO missionDTO = MissionDTO
-//                .builder()
-//                .title("test_title")
-//                .contents("test_contents")
-//                .goalHours(2)
-//                .build();
-//
-//        Mission mission = new Mission(loginMember, missionDTO);
-//
-//        when(missionRepository.findById(any())).thenReturn(Optional.of(mission));
-//        missionService.completeMission(loginMember, 0l);
-//
-//        assertEquals(true, missionService.findById(0l));
+        MissionDTO missionDTO = MissionDTO
+                .builder()
+                .title("test_title")
+                .contents("test_contents")
+                .deadlineTime("09:00:00")
+                .build();
+
+        Mission mission = new Mission(loginMember, missionDTO);
+
+        when(missionRepository.findById(any())).thenReturn(Optional.of(mission));
+        missionService.completeMission(loginMember, 0l, LocalTime.of(9, 1));
+
+        assertEquals(MissionStatus.COMPLETE, missionService.findById(0l).getStatus());
     }
 
     private List<Mission> setMockMissionList() {
         Mission mission1 = Mission.builder()
                                   .title("test1")
                                   .contents("test_contents")
-                                  .goalSeconds(2)
+                                  .deadlineTime(LocalTime.of(9, 0))
                                   .writer(loginMember)
                                   .build();
 
         Mission mission2 = Mission.builder()
                                   .title("test2")
                                   .contents("test_contents")
-                                  .goalSeconds(2)
+                                  .deadlineTime(LocalTime.of(9, 0))
                                   .writer(loginMember)
                                   .build();
 
         Mission mission3 = Mission.builder()
                                   .title("test3")
                                   .contents("test_contents")
-                                  .goalSeconds(2)
+                                  .deadlineTime(LocalTime.of(9, 0))
                                   .writer(new Member())
                                   .build();
 

--- a/src/test/java/com/sproutt/eussyaeussyaapi/application/MissionServiceTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/application/MissionServiceTest.java
@@ -6,7 +6,6 @@ import com.sproutt.eussyaeussyaapi.application.mission.MissionServiceImpl;
 import com.sproutt.eussyaeussyaapi.domain.member.Member;
 import com.sproutt.eussyaeussyaapi.domain.mission.Mission;
 import com.sproutt.eussyaeussyaapi.domain.mission.MissionRepository;
-import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NoSuchMissionException;
 import com.sproutt.eussyaeussyaapi.object.MemberFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,7 +19,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -41,7 +39,7 @@ public class MissionServiceTest {
 
     @Test
     @DisplayName("미션 생성 테스트")
-    public void createMission() {
+    void createMission() {
         MissionDTO missionDTO = MissionDTO
                 .builder()
                 .title("test_title")
@@ -59,13 +57,13 @@ public class MissionServiceTest {
 
     @Test
     @DisplayName("미션 조회 테스트")
-    public void searchMission() {
+    void searchMission() {
         Mission mission = Mission.builder()
-                .title("test")
-                .contents("test_contents")
-                .goalSeconds(2)
-                .writer(loginMember)
-                .build();
+                                 .title("test")
+                                 .contents("test_contents")
+                                 .goalSeconds(2)
+                                 .writer(loginMember)
+                                 .build();
 
         when(missionRepository.findById(any(Long.class))).thenReturn(Optional.of(mission));
 
@@ -76,7 +74,7 @@ public class MissionServiceTest {
 
     @Test
     @DisplayName("미션리스트 작성자 기준 조회 테스트")
-    public void searchMissionList_withWriter() {
+    void searchMissionList_withWriter() {
         List<Mission> filteredMissionList = mockedMissionList.stream()
                                                              .filter(mission -> mission.getWriter().equals(loginMember))
                                                              .collect(Collectors.toList());
@@ -91,7 +89,7 @@ public class MissionServiceTest {
 
     @Test
     @DisplayName("미션리스트 날짜 기준 조회 테스트")
-    public void searchMissionList_withDate() {
+    void searchMissionList_withDate() {
         List<Mission> missionList = missionService.filterDate(null, null, mockedMissionList);
 
         assertEquals(3, missionList.size());
@@ -99,7 +97,7 @@ public class MissionServiceTest {
 
     @Test
     @DisplayName("미션 수정 테스트")
-    public void updateMission() {
+    void updateMission() {
 //        MissionDTO missionDTO = MissionDTO
 //                .builder()
 //                .title("test_title")
@@ -126,7 +124,7 @@ public class MissionServiceTest {
 
     @Test
     @DisplayName("미션 삭제 테스트")
-    public void deleteMission() {
+    void deleteMission() {
 //        MissionDTO missionDTO = MissionDTO
 //                .builder()
 //                .title("test_title")
@@ -140,6 +138,24 @@ public class MissionServiceTest {
 //        missionService.delete(loginMember, 0l);
 //
 //        assertThrows(NoSuchMissionException.class,() -> missionService.findById(0l));
+    }
+
+    @Test
+    @DisplayName("미션 완료 테스트")
+    void completeMission() {
+//        MissionDTO missionDTO = MissionDTO
+//                .builder()
+//                .title("test_title")
+//                .contents("test_contents")
+//                .goalHours(2)
+//                .build();
+//
+//        Mission mission = new Mission(loginMember, missionDTO);
+//
+//        when(missionRepository.findById(any())).thenReturn(Optional.of(mission));
+//        missionService.completeMission(loginMember, 0l);
+//
+//        assertEquals(true, missionService.findById(0l));
     }
 
     private List<Mission> setMockMissionList() {

--- a/src/test/java/com/sproutt/eussyaeussyaapi/application/MissionServiceTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/application/MissionServiceTest.java
@@ -1,0 +1,174 @@
+package com.sproutt.eussyaeussyaapi.application;
+
+import com.sproutt.eussyaeussyaapi.api.mission.dto.MissionDTO;
+import com.sproutt.eussyaeussyaapi.application.mission.MissionService;
+import com.sproutt.eussyaeussyaapi.application.mission.MissionServiceImpl;
+import com.sproutt.eussyaeussyaapi.domain.member.Member;
+import com.sproutt.eussyaeussyaapi.domain.mission.Mission;
+import com.sproutt.eussyaeussyaapi.domain.mission.MissionRepository;
+import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.NoSuchMissionException;
+import com.sproutt.eussyaeussyaapi.object.MemberFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class MissionServiceTest {
+    private MissionRepository missionRepository = mock(MissionRepository.class);
+    private MissionService missionService;
+    private Member loginMember;
+    private List<Mission> mockedMissionList;
+
+    @BeforeEach
+    void setUp() {
+        missionService = new MissionServiceImpl(missionRepository);
+        loginMember = MemberFactory.getDefaultMember();
+        mockedMissionList = setMockMissionList();
+    }
+
+    @Test
+    @DisplayName("미션 생성 테스트")
+    public void createMission() {
+        MissionDTO missionDTO = MissionDTO
+                .builder()
+                .title("test_title")
+                .contents("test_contents")
+                .goalHours(2)
+                .build();
+
+        Mission mission = new Mission(loginMember, missionDTO);
+
+        when(missionRepository.save(any(Mission.class))).thenReturn(mission);
+        Mission savedMission = missionService.create(loginMember, missionDTO);
+
+        assertEquals(mission.getTitle(), savedMission.getTitle());
+    }
+
+    @Test
+    @DisplayName("미션 조회 테스트")
+    public void searchMission() {
+        Mission mission = Mission.builder()
+                .title("test")
+                .contents("test_contents")
+                .goalSeconds(2)
+                .writer(loginMember)
+                .build();
+
+        when(missionRepository.findById(any(Long.class))).thenReturn(Optional.of(mission));
+
+        Mission searchedMission = missionService.findById(mission.getId());
+
+        assertEquals(mission.getTitle(), searchedMission.getTitle());
+    }
+
+    @Test
+    @DisplayName("미션리스트 작성자 기준 조회 테스트")
+    public void searchMissionList_withWriter() {
+        List<Mission> filteredMissionList = mockedMissionList.stream()
+                                                             .filter(mission -> mission.getWriter().equals(loginMember))
+                                                             .collect(Collectors.toList());
+
+        when(missionRepository.findAllByWriter(loginMember))
+                .thenReturn(filteredMissionList);
+
+        List<Mission> missionList = missionService.findByWriter(loginMember);
+
+        assertEquals(filteredMissionList.size(), missionList.size());
+    }
+
+    @Test
+    @DisplayName("미션리스트 날짜 기준 조회 테스트")
+    public void searchMissionList_withDate() {
+        List<Mission> missionList = missionService.filterDate(null, null, mockedMissionList);
+
+        assertEquals(3, missionList.size());
+    }
+
+    @Test
+    @DisplayName("미션 수정 테스트")
+    public void updateMission() {
+//        MissionDTO missionDTO = MissionDTO
+//                .builder()
+//                .title("test_title")
+//                .contents("test_contents")
+//                .goalHours(2)
+//                .build();
+//
+//        Mission mission = new Mission(loginMember, missionDTO);
+//
+//        MissionDTO updatedMissionDTO = MissionDTO
+//                .builder()
+//                .title("test_title2")
+//                .contents("test_contents2")
+//                .goalHours(3)
+//                .build();
+//
+//        when(missionRepository.findById(0l)).thenReturn(Optional.of(mission));
+//        when(missionRepository.save(any())).thenReturn(new Mission(loginMember, updatedMissionDTO));
+//
+//        Mission updatedMission = missionService.update(loginMember, 0l, missionDTO);
+//
+//        assertEquals(updatedMissionDTO.getTitle(), updatedMission.getTitle());
+    }
+
+    @Test
+    @DisplayName("미션 삭제 테스트")
+    public void deleteMission() {
+//        MissionDTO missionDTO = MissionDTO
+//                .builder()
+//                .title("test_title")
+//                .contents("test_contents")
+//                .goalHours(2)
+//                .build();
+//
+//        Mission mission = new Mission(loginMember, missionDTO);
+//
+//        when(missionRepository.findById(0l)).thenReturn(Optional.of(mission));
+//        missionService.delete(loginMember, 0l);
+//
+//        assertThrows(NoSuchMissionException.class,() -> missionService.findById(0l));
+    }
+
+    private List<Mission> setMockMissionList() {
+        Mission mission1 = Mission.builder()
+                                  .title("test1")
+                                  .contents("test_contents")
+                                  .goalSeconds(2)
+                                  .writer(loginMember)
+                                  .build();
+
+        Mission mission2 = Mission.builder()
+                                  .title("test2")
+                                  .contents("test_contents")
+                                  .goalSeconds(2)
+                                  .writer(loginMember)
+                                  .build();
+
+        Mission mission3 = Mission.builder()
+                                  .title("test3")
+                                  .contents("test_contents")
+                                  .goalSeconds(2)
+                                  .writer(new Member())
+                                  .build();
+
+        List<Mission> mockedMissionsList = new ArrayList<>();
+        mockedMissionsList.add(mission1);
+        mockedMissionsList.add(mission2);
+        mockedMissionsList.add(mission3);
+
+        return mockedMissionsList;
+    }
+}


### PR DESCRIPTION
#68 

- 미션 생성: POST "/missions" missionDTO{title : string, contents : string, goalHours : int}  // 새벽만 가능, 유효 jwt 필요
- 미션 조회
    - 단일 미션 : GET "/missions/{missionId}"
    - 미션 리스트 : GET "/missions?writer={memberId}&after={조회시작날짜}&before={조회종료날짜}"
- 미션 수정: PUT "/missions/{missionId}" missionDTO{title : string, contents : string, goalHours : int}  // 새벽만 가능, 유효 jwt 필요
- 미션 삭제 : DELETE "/missions/{missionId}" // 유효 jwt 필요
- 미션 진행 시간 업데이트 : PUT "/missions/{missionId}/seconds" {processSeconds : long} // 새벽만 가능, 유효 jwt 필요
- 미션 완료 : PUT "/missions/{missionId}/complete" // 새벽만 가능, 유효 jwt 필요
