### PR TITLE
refactor : 인증코드 생성 방식 변경

### DIFF
--- a/src/main/java/com/sproutt/eussyaeussyaapi/utils/RandomGenerator.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/utils/RandomGenerator.java
@@ -1,21 +1,9 @@
 package com.sproutt.eussyaeussyaapi.utils;
 
-import java.util.Random;
+import java.util.UUID;
 
 public class RandomGenerator {
-    private static final int AUTHENTICATION_CODE_LENGTH = 8;
-    private static final char[] CHARSET = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
-            'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
-            'Y', 'Z', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0'};
-
     public static String createAuthenticationCode() {
-        StringBuilder code = new StringBuilder();
-        Random random = new Random(System.currentTimeMillis());
-
-        while (code.length() != AUTHENTICATION_CODE_LENGTH) {
-            code.append(CHARSET[random.nextInt(CHARSET.length)]);
-        }
-
-        return code.toString();
+        return UUID.randomUUID().toString();
     }
 }


### PR DESCRIPTION
안녕하세요! 스프링부트 프로젝트를 보고 지나가다가 PR한번 날려봅니다.
인증코드 생성방식에서 random한 8자리 문자열을 생성해서 메일을 인증하기 위한 코드로 사용하시는데 8자리 문자열을 랜덤하게 생성하는 경우 운이 안좋다면 사용자끼리 문자열이 겹칠 수 있습니다.
UUID같은경우 운영 환경에서 거의 문자열이 겹치치 않도록 한다는 말을 들어본것 같아서 해당 코드를 UUID를 random하게 바꾸는 코드로 refactoring하고 develop 브랜치에 PR 날려봅니다.

