### PR TITLE
[Back] messages.properties 등록한 valid 메시지가 뜨지 않은 문제 해결

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,9 +1,9 @@
-Email.loginDTO.memberId=이메일 형식이 올바르지 않습니다.
-NotBlank.loginDTO.password=비밀번호를 입력해 주세요.
+Email.memberLoginCommand.memberId=이메일 형식이 올바르지 않습니다.
+NotBlank.memberLoginCommand.password=비밀번호를 입력해 주세요.
 
-NotBlank.joinDTO.memberId=이메일을 입력해 주세요.
-Size.joinDTO.nickName=닉네임은 2~10자로 입력해주세요.
-Pattern.joinDTO.password=영문, 숫자, 특수문자 중 두 가지 이상 포함 6~15자리 비밀번호를 입력해 주세요.
+NotBlank.memberJoinCommand.memberId=이메일을 입력해 주세요.
+Size.memberJoinCommand.nickName=닉네임은 2~10자로 입력해주세요.
+Pattern.memberJoinCommand.password=영문, 숫자, 특수문자 중 두 가지 이상 포함 6~15자리 비밀번호를 입력해 주세요.
 
 Email.member.email=이메일 형식이 올바르지 않습니다.
 


### PR DESCRIPTION
**문제**
- messages.properties에 지정한 메세지가 아닌 default 메세지가 출력되고 있어 test가 통과 못하고 있었음

**원인**
- dto 객체들의 이름 변경으로 인해 매핑이 되지 않았음 (ex. joinDTO -> MemberJoinCommand)

**해결**
- messages.properties 메세지를 받을 객체 이름을 수정하여 해결