### PR TITLE
[Back] Refresh Token 적용 #119

### DIFF
--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/aspect/member/MemberAspect.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/aspect/member/MemberAspect.java
@@ -18,8 +18,8 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 public class MemberAspect {
 
-    @Value("${jwt.header}")
-    private String tokenKey;
+    @Value("${jwt.accessTokenKey}")
+    private String accessTokenKey;
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -35,7 +35,7 @@ public class MemberAspect {
                                       .findFirst()
                                       .orElseThrow(NoPermissionException::new);
 
-        String token = headers.getFirst(tokenKey);
+        String token = headers.getFirst(accessTokenKey);
         MemberTokenCommand memberTokenCommand = jwtHelper.decryptToken(secretKey, token);
 
         for (int i = 0; i < joinPointArgs.length; i++) {

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/config/WebConfig.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/config/WebConfig.java
@@ -20,8 +20,8 @@ public class WebConfig implements WebMvcConfigurer {
     @Value("${api.cors.allow-origins}")
     private String allowedOrigins;
 
-    @Value("${jwt.header}")
-    private String tokenKey;
+    @Value("${jwt.accessTokenKey}")
+    private String accessTokenKey;
 
     private final JwtInterceptor jwtInterceptor;
 
@@ -46,7 +46,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .exposedHeaders(tokenKey)
+                .exposedHeaders(accessTokenKey)
                 .allowedMethods("GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowCredentials(true)
                 .allowedOrigins(allowedOrigins.split(", "));

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/config/WebConfig.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/config/WebConfig.java
@@ -29,7 +29,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtInterceptor)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/signUp/**", "/phrase/**", "/social/**", "/then/**", "/members/**", "/login/**", "/webjars/**", "/swagger-resources/**", "/v2/**", "/email-auth/**", "/swagger-ui.html");
+                .excludePathPatterns("/auth/**", "/signUp/**", "/phrase/**", "/social/**", "/then/**", "/members/**", "/login/**", "/webjars/**", "/swagger-resources/**", "/v2/**", "/email-auth/**", "/swagger-ui.html");
     }
 
     @Bean

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/exception/GlobalExceptionHandler.java
@@ -6,7 +6,8 @@ import com.sproutt.eussyaeussyaapi.api.exception.dto.ValidateError;
 import com.sproutt.eussyaeussyaapi.api.exception.dto.ValidationErrorResponse;
 import com.sproutt.eussyaeussyaapi.api.oauth2.exception.OAuth2CommunicationException;
 import com.sproutt.eussyaeussyaapi.api.oauth2.exception.UnSupportedOAuth2Exception;
-import com.sproutt.eussyaeussyaapi.api.security.exception.InvalidTokenException;
+import com.sproutt.eussyaeussyaapi.api.security.exception.InvalidAccessTokenException;
+import com.sproutt.eussyaeussyaapi.api.security.exception.InvalidRefreshTokenException;
 import com.sproutt.eussyaeussyaapi.domain.member.exceptions.*;
 import com.sproutt.eussyaeussyaapi.domain.mission.exceptions.*;
 import javassist.NotFoundException;
@@ -95,9 +96,19 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().contentType(MediaType.APPLICATION_JSON).body(exception.getMessage());
     }
 
-    @ExceptionHandler(value = InvalidTokenException.class)
-    public ResponseEntity<ErrorResponse> handleInvalidTokenException(InvalidTokenException exception) {
-        log.info("handleInvalidTokenException : {}", exception);
+    @ExceptionHandler(value = InvalidAccessTokenException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidAccessTokenException(InvalidAccessTokenException exception) {
+        log.info("handleInvalidAccessTokenException : {}", exception);
+
+        ErrorResponse response = new ErrorResponse();
+        response.of(ErrorCode.INVALID_TOKEN);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(MediaType.APPLICATION_JSON).body(response);
+    }
+
+    @ExceptionHandler(value = InvalidAccessTokenException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidRefreshTokenException(InvalidRefreshTokenException exception) {
+        log.info("handleInvalidRefreshTokenException : {}", exception);
 
         ErrorResponse response = new ErrorResponse();
         response.of(ErrorCode.INVALID_TOKEN);

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/exception/GlobalExceptionHandler.java
@@ -106,7 +106,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(MediaType.APPLICATION_JSON).body(response);
     }
 
-    @ExceptionHandler(value = InvalidAccessTokenException.class)
+    @ExceptionHandler(value = InvalidRefreshTokenException.class)
     public ResponseEntity<ErrorResponse> handleInvalidRefreshTokenException(InvalidRefreshTokenException exception) {
         log.info("handleInvalidRefreshTokenException : {}", exception);
 

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
@@ -27,8 +27,8 @@ import java.util.List;
 @Api(description = "으쌰으쌰 회원 관련 API", tags = {"Member - 담당자 : 김종근"})
 public class MemberController {
 
-    @Value("${jwt.header}")
-    private String tokenKey;
+    @Value("${jwt.accessTokenKey}")
+    private String accessTokenKey;
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -69,11 +69,11 @@ public class MemberController {
     public ResponseEntity loginMember(@Valid @RequestBody MemberLoginCommand memberLoginCommand) {
         Member loginMember = memberService.login(memberLoginCommand);
 
-        String token = jwtHelper.createToken(secretKey, loginMember.toJwtInfo());
+        String token = jwtHelper.createAccessToken(secretKey, loginMember.toJwtInfo());
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set(tokenKey, token);
+        headers.set(accessTokenKey, token);
 
         return new ResponseEntity<>(headers, HttpStatus.OK);
     }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
@@ -30,6 +30,9 @@ public class MemberController {
     @Value("${jwt.accessTokenKey}")
     private String accessTokenKey;
 
+    @Value("${jwt.refreshTokenKey}")
+    private String refreshTokenKey;
+
     @Value("${jwt.secret}")
     private String secretKey;
 
@@ -69,11 +72,13 @@ public class MemberController {
     public ResponseEntity loginMember(@Valid @RequestBody MemberLoginCommand memberLoginCommand) {
         Member loginMember = memberService.login(memberLoginCommand);
 
-        String token = jwtHelper.createAccessToken(secretKey, loginMember.toJwtInfo());
+        String accessToken = jwtHelper.createAccessToken(secretKey, loginMember.toJwtInfo());
+        String refreshToken = jwtHelper.createRefreshToken(secretKey, loginMember.toJwtInfo());
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set(accessTokenKey, token);
+        headers.set(accessTokenKey, accessToken);
+        headers.set(refreshTokenKey, refreshToken);
 
         return new ResponseEntity<>(headers, HttpStatus.OK);
     }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
@@ -4,6 +4,7 @@ import com.sproutt.eussyaeussyaapi.api.member.dto.MemberJoinCommand;
 import com.sproutt.eussyaeussyaapi.api.member.dto.MemberLoginCommand;
 import com.sproutt.eussyaeussyaapi.api.mission.dto.MemberDTO;
 import com.sproutt.eussyaeussyaapi.api.security.JwtHelper;
+import com.sproutt.eussyaeussyaapi.api.security.dto.JwtDTO;
 import com.sproutt.eussyaeussyaapi.application.member.MemberService;
 import com.sproutt.eussyaeussyaapi.domain.member.Member;
 import com.sproutt.eussyaeussyaapi.domain.member.exceptions.DuplicationMemberException;
@@ -69,7 +70,7 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity loginMember(@Valid @RequestBody MemberLoginCommand memberLoginCommand) {
+    public ResponseEntity<JwtDTO> loginMember(@Valid @RequestBody MemberLoginCommand memberLoginCommand) {
         Member loginMember = memberService.login(memberLoginCommand);
 
         String accessToken = jwtHelper.createAccessToken(secretKey, loginMember.toJwtInfo());
@@ -77,10 +78,8 @@ public class MemberController {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set(accessTokenKey, accessToken);
-        headers.set(refreshTokenKey, refreshToken);
 
-        return new ResponseEntity<>(headers, HttpStatus.OK);
+        return new ResponseEntity<>(new JwtDTO(accessToken, refreshToken), headers, HttpStatus.OK);
     }
 
     @PostMapping("/members/{memberId}/authcode")

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/member/MemberController.java
@@ -28,12 +28,6 @@ import java.util.List;
 @Api(description = "으쌰으쌰 회원 관련 API", tags = {"Member - 담당자 : 김종근"})
 public class MemberController {
 
-    @Value("${jwt.accessTokenKey}")
-    private String accessTokenKey;
-
-    @Value("${jwt.refreshTokenKey}")
-    private String refreshTokenKey;
-
     @Value("${jwt.secret}")
     private String secretKey;
 

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialController.java
@@ -4,6 +4,7 @@ import com.sproutt.eussyaeussyaapi.api.oauth2.dto.OAuth2UserInfoDTO;
 import com.sproutt.eussyaeussyaapi.api.oauth2.service.OAuth2RequestService;
 import com.sproutt.eussyaeussyaapi.api.oauth2.service.OAuth2RequestServiceFactory;
 import com.sproutt.eussyaeussyaapi.api.security.JwtHelper;
+import com.sproutt.eussyaeussyaapi.api.security.dto.JwtDTO;
 import com.sproutt.eussyaeussyaapi.application.member.MemberService;
 import com.sproutt.eussyaeussyaapi.domain.member.Member;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,7 +38,7 @@ public class SocialController {
     }
 
     @PostMapping("/login/{provider}")
-    public ResponseEntity loginByProvider(@PathVariable String provider, @RequestParam String token) {
+    public ResponseEntity<JwtDTO> loginByProvider(@PathVariable String provider, @RequestParam String token) {
         OAuth2RequestService oAuth2RequestService = oAuth2RequestServiceFactory.getOAuth2RequestService(provider);
 
         OAuth2UserInfoDTO userInfoDTO = oAuth2RequestService.getUserInfo(token);
@@ -49,9 +50,7 @@ public class SocialController {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set(accessTokenKey, accessToken);
-        headers.set(refreshTokenKey, refreshToken);
 
-        return new ResponseEntity<>(headers, HttpStatus.OK);
+        return new ResponseEntity<>(new JwtDTO(accessToken, refreshToken), headers, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialController.java
@@ -24,6 +24,9 @@ public class SocialController {
     @Value("${jwt.accessTokenKey}")
     private String accessTokenKey;
 
+    @Value("${jwt.refreshTokenKey}")
+    private String refreshTokenKey;
+
     @Value("${jwt.secret}")
     private String secretKey;
 
@@ -34,18 +37,20 @@ public class SocialController {
     }
 
     @PostMapping("/login/{provider}")
-    public ResponseEntity loginByProvider(@PathVariable String provider, @RequestParam String accessToken) {
+    public ResponseEntity loginByProvider(@PathVariable String provider, @RequestParam String token) {
         OAuth2RequestService oAuth2RequestService = oAuth2RequestServiceFactory.getOAuth2RequestService(provider);
 
-        OAuth2UserInfoDTO userInfoDTO = oAuth2RequestService.getUserInfo(accessToken);
+        OAuth2UserInfoDTO userInfoDTO = oAuth2RequestService.getUserInfo(token);
         Member loginMember = userInfoDTO.toEntity();
 
         memberService.loginWithSocialProvider(userInfoDTO);
-        String token = jwtHelper.createAccessToken(secretKey, loginMember.toJwtInfo());
+        String accessToken = jwtHelper.createAccessToken(secretKey, loginMember.toJwtInfo());
+        String refreshToken = jwtHelper.createRefreshToken(secretKey, loginMember.toJwtInfo());
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set(accessTokenKey, token);
+        headers.set(accessTokenKey, accessToken);
+        headers.set(refreshTokenKey, refreshToken);
 
         return new ResponseEntity<>(headers, HttpStatus.OK);
     }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialController.java
@@ -21,8 +21,8 @@ public class SocialController {
     private final MemberService memberService;
     private final OAuth2RequestServiceFactory oAuth2RequestServiceFactory;
 
-    @Value("${jwt.header}")
-    private String tokenKey;
+    @Value("${jwt.accessTokenKey}")
+    private String accessTokenKey;
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -41,11 +41,11 @@ public class SocialController {
         Member loginMember = userInfoDTO.toEntity();
 
         memberService.loginWithSocialProvider(userInfoDTO);
-        String token = jwtHelper.createToken(secretKey, loginMember.toJwtInfo());
+        String token = jwtHelper.createAccessToken(secretKey, loginMember.toJwtInfo());
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set(tokenKey, token);
+        headers.set(accessTokenKey, token);
 
         return new ResponseEntity<>(headers, HttpStatus.OK);
     }

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialController.java
@@ -22,12 +22,6 @@ public class SocialController {
     private final MemberService memberService;
     private final OAuth2RequestServiceFactory oAuth2RequestServiceFactory;
 
-    @Value("${jwt.accessTokenKey}")
-    private String accessTokenKey;
-
-    @Value("${jwt.refreshTokenKey}")
-    private String refreshTokenKey;
-
     @Value("${jwt.secret}")
     private String secretKey;
 

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/security/AuthController.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/security/AuthController.java
@@ -1,0 +1,43 @@
+package com.sproutt.eussyaeussyaapi.api.security;
+
+import com.sproutt.eussyaeussyaapi.api.security.dto.JwtDTO;
+import com.sproutt.eussyaeussyaapi.api.security.exception.InvalidRefreshTokenException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AuthController {
+
+    @Value("${jwt.refreshTokenKey}")
+    private String refreshTokenKey;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Autowired
+    private JwtHelper jwtHelper;
+
+    @PostMapping("/auth/accesstoken")
+    public ResponseEntity<JwtDTO> issueNewAccessToken(@RequestHeader HttpHeaders requestHeaders) {
+        String refreshToken = requestHeaders.getFirst(refreshTokenKey);
+
+        if (!jwtHelper.isUsable(secretKey, refreshToken)) {
+            throw new InvalidRefreshTokenException();
+        }
+
+        // TODO redis 정보랑 token payload 비교
+        String accessToken = jwtHelper.createAccessToken(secretKey, jwtHelper.decryptToken(secretKey, refreshToken));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return new ResponseEntity<>(new JwtDTO(accessToken, refreshToken), headers, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtHelper.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtHelper.java
@@ -20,8 +20,9 @@ public class JwtHelper {
     }
 
     public String createRefreshToken(String secretKey, MemberTokenCommand memberTokenCommand) {
+        String token = createToken(secretKey, memberTokenCommand, REFRESH_TOKEN_VALID_MILLISECOND);
         // TODO: 20. 12. 4. Redis 연동하기
-        return createToken(secretKey, memberTokenCommand, REFRESH_TOKEN_VALID_MILLISECOND);
+        return token;
     }
 
     private String createToken(String secretKey, MemberTokenCommand memberTokenCommand, long validMilisecond) {

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtHelper.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtHelper.java
@@ -10,12 +10,21 @@ import java.util.Date;
 @Component
 public class JwtHelper {
 
-    private static final long VALID_MILLISECOND = 1000L * 60 * 60 * 24; // 24 hour
+    private static final long ACCESS_TOKEN_VALID_MILLISECOND = 1000L * 60 * 60 * 24; // 24 hour
+    private static final long REFRESH_TOKEN_VALID_MILLISECOND = 7 * 1000L * 60 * 60 * 24; // 7 Days
 
     private static final String CLAIM_KEY = "member";
 
-    public String createToken(String secretKey, MemberTokenCommand memberTokenCommand) {
+    public String createAccessToken(String secretKey, MemberTokenCommand memberTokenCommand) {
+        return createToken(secretKey, memberTokenCommand, ACCESS_TOKEN_VALID_MILLISECOND);
+    }
 
+    public String createRefreshToken(String secretKey, MemberTokenCommand memberTokenCommand) {
+        // TODO: 20. 12. 4. Redis 연동하기
+        return createToken(secretKey, memberTokenCommand, REFRESH_TOKEN_VALID_MILLISECOND);
+    }
+
+    private String createToken(String secretKey, MemberTokenCommand memberTokenCommand, long validMilisecond) {
         Claims claims = Jwts.claims().setSubject(CLAIM_KEY);
         claims.put(CLAIM_KEY, memberTokenCommand);
 
@@ -25,7 +34,7 @@ public class JwtHelper {
                            .setHeaderParam("typ", "jwt")
                            .setClaims(claims)
                            .setIssuedAt(now)
-                           .setExpiration(new Date(now.getTime() + VALID_MILLISECOND))
+                           .setExpiration(new Date(now.getTime() + validMilisecond))
                            .signWith(SignatureAlgorithm.HS256, secretKey)
                            .compact();
 

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtInterceptor.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtInterceptor.java
@@ -1,6 +1,6 @@
 package com.sproutt.eussyaeussyaapi.api.security;
 
-import com.sproutt.eussyaeussyaapi.api.security.exception.InvalidTokenException;
+import com.sproutt.eussyaeussyaapi.api.security.exception.InvalidAccessTokenException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,11 +33,10 @@ public class JwtInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        String token = request.getHeader(accessTokenKey);
-        String refreshToken = request.getHeader(refreshTokenKey);
+        String accessToken = request.getHeader(accessTokenKey);
 
-        if (token == null || !jwtHelper.isUsable(secretKey, token)) {
-            throw new InvalidTokenException();
+        if (!jwtHelper.isUsable(secretKey, accessToken)) {
+            throw new InvalidAccessTokenException();
         }
 
         return true;

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtInterceptor.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtInterceptor.java
@@ -14,8 +14,11 @@ import javax.servlet.http.HttpServletResponse;
 @Component
 public class JwtInterceptor implements HandlerInterceptor {
 
-    @Value("${jwt.header}")
-    private String tokenKey;
+    @Value("${jwt.accessTokenKey}")
+    private String accessTokenKey;
+
+    @Value("${jwt.refreshTokenKey}")
+    private String refreshTokenKey;
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -30,7 +33,8 @@ public class JwtInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        String token = request.getHeader(tokenKey);
+        String token = request.getHeader(accessTokenKey);
+        String refreshToken = request.getHeader(refreshTokenKey);
 
         if (token == null || !jwtHelper.isUsable(secretKey, token)) {
             throw new InvalidTokenException();

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/security/dto/JwtDTO.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/security/dto/JwtDTO.java
@@ -1,0 +1,19 @@
+package com.sproutt.eussyaeussyaapi.api.security.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class JwtDTO {
+
+    private String accessToken;
+    private String refreshToken;
+
+    public JwtDTO(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/security/exception/InvalidAccessTokenException.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/security/exception/InvalidAccessTokenException.java
@@ -1,0 +1,9 @@
+package com.sproutt.eussyaeussyaapi.api.security.exception;
+
+import com.sproutt.eussyaeussyaapi.utils.ExceptionMessage;
+
+public class InvalidAccessTokenException extends RuntimeException {
+    public InvalidAccessTokenException() {
+        super(ExceptionMessage.INVALID_ACCESS_TOKEN);
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/security/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/security/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,9 @@
+package com.sproutt.eussyaeussyaapi.api.security.exception;
+
+import com.sproutt.eussyaeussyaapi.utils.ExceptionMessage;
+
+public class InvalidRefreshTokenException extends RuntimeException {
+    public InvalidRefreshTokenException() {
+        super(ExceptionMessage.INVALID_REFRESH_TOKEN);
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/security/exception/InvalidTokenException.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/security/exception/InvalidTokenException.java
@@ -1,9 +1,0 @@
-package com.sproutt.eussyaeussyaapi.api.security.exception;
-
-import com.sproutt.eussyaeussyaapi.utils.ExceptionMessage;
-
-public class InvalidTokenException extends RuntimeException {
-    public InvalidTokenException() {
-        super(ExceptionMessage.INVALID_TOKEN);
-    }
-}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/utils/ExceptionMessage.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/utils/ExceptionMessage.java
@@ -9,7 +9,8 @@ public class ExceptionMessage {
     public static final String OAUTH_COMMUNICATION_ERROR = "oauth 통신 중 오류가 발생하였습니다.";
     public static final String UNSUPPORT_OAUTH = "지원하지 않거나 존재하지 않는 oauth 입니다.";
     public static final String FAILED_VERIFICATION = "인증 실패";
-    public static final String INVALID_TOKEN = "유효하지 않은 토큰";
+    public static final String INVALID_ACCESS_TOKEN = "유효하지 않은 Access 토큰";
+    public static final String INVALID_REFRESH_TOKEN = "유효하지 않은 Refresh 토큰";
     public static final String NOT_AVAILABLE_TIME = "서비스 시간이 아닙니다.";
     public static final String NO_SUCH_MISSION = "존재하지 않는 미션입니다.";
     public static final String NO_PERMISSION = "권한 없음";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,8 @@ logging:
             sql: trace
 
 jwt:
-  header: Authorization
+  accessTokenKey: Authorization
+  refreshTokenKey: Refresh-Authorization
   secret: secret
 
 social:

--- a/src/test/java/com/sproutt/eussyaeussyaapi/acceptance/MissionAcceptanceTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/acceptance/MissionAcceptanceTest.java
@@ -52,8 +52,8 @@ public class MissionAcceptanceTest {
     private MissionRepository missionRepository;
 
 
-    @Value("${jwt.header}")
-    private String tokenKey;
+    @Value("${jwt.accessTokenKey}")
+    private String accessTokenKey;
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -77,7 +77,7 @@ public class MissionAcceptanceTest {
         memberRepository.saveAndFlush(member);
         missionRepository.saveAndFlush(mission);
 
-        token = jwtHelper.createToken(secretKey, MemberTokenCommand.builder()
+        token = jwtHelper.createAccessToken(secretKey, MemberTokenCommand.builder()
                                                                    .id(member.getId())
                                                                    .memberId(member.getMemberId())
                                                                    .nickName(member.getNickName()).build());
@@ -85,7 +85,7 @@ public class MissionAcceptanceTest {
         template.getRestTemplate().setInterceptors(
                 Collections.singletonList((request, body, execution) -> {
                     request.getHeaders()
-                           .add(tokenKey, token);
+                           .add(accessTokenKey, token);
                     request.getHeaders()
                            .setZonedDateTime("date", ZonedDateTime.of(2020, 7, 15, 5, 0, 0, 0, ZoneId.of("Asia/Seoul")));
                     return execution.execute(request, body);
@@ -171,7 +171,7 @@ public class MissionAcceptanceTest {
         template.getRestTemplate().setInterceptors(
                 Collections.singletonList((request, body, execution) -> {
                     request.getHeaders()
-                           .add(tokenKey, token);
+                           .add(accessTokenKey, token);
                     request.getHeaders()
                            .setZonedDateTime("date", ZonedDateTime.of(2020, 7, 15, 5, 1, 0, 0, ZoneId.of("Asia/Seoul")));
                     return execution.execute(request, body);

--- a/src/test/java/com/sproutt/eussyaeussyaapi/acceptance/SocialAcceptanceTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/acceptance/SocialAcceptanceTest.java
@@ -80,7 +80,7 @@ public class SocialAcceptanceTest {
 
     private HttpHeaders getHeader(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
-        headers.set("accessToken", accessToken);
+        headers.set("token", accessToken);
 
         return headers;
     }

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/HeaderSetUpWithToken.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/HeaderSetUpWithToken.java
@@ -19,8 +19,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(SpringExtension.class)
 public class HeaderSetUpWithToken {
 
-    @Value("${jwt.header}")
-    private String tokenKey;
+    @Value("${jwt.accessTokenKey}")
+    private String accessTokenKey;
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -33,12 +33,12 @@ public class HeaderSetUpWithToken {
 
     public HttpHeaders setUpHeader() throws Exception {
         Member loginMember = MemberFactory.getDefaultMember();
-        when(jwtHelper.createToken(any(), any())).thenReturn("token");
-        String token = jwtHelper.createToken(secretKey, loginMember.toJwtInfo());
+        when(jwtHelper.createAccessToken(any(), any())).thenReturn("token");
+        String token = jwtHelper.createAccessToken(secretKey, loginMember.toJwtInfo());
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set(tokenKey, token);
+        headers.set(accessTokenKey, token);
         headers.setZonedDateTime("date", ZonedDateTime.now());
 
         when(jwtInterceptor.preHandle(any(), any(), any())).thenReturn(true);

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialControllerTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialControllerTest.java
@@ -61,7 +61,7 @@ class SocialControllerTest {
         when(oAuth2RequestService.getUserInfo(eq("token")))
                 .thenReturn(userInfoDTO);
         when(memberService.loginWithSocialProvider(userInfoDTO)).thenReturn(githubMember);
-        when(jwtHelper.createToken(any(), any())).thenReturn("token");
+        when(jwtHelper.createAccessToken(any(), any())).thenReturn("token");
 
         ResultActions actions = mockMvc.perform(post("/social/login/github")
                 .param("accessToken", "token")
@@ -82,7 +82,7 @@ class SocialControllerTest {
         when(oAuth2RequestService.getUserInfo(eq("token")))
                 .thenReturn(userInfoDTO);
         when(memberService.loginWithSocialProvider(userInfoDTO)).thenReturn(facebookMember);
-        when(jwtHelper.createToken(any(), any())).thenReturn("token");
+        when(jwtHelper.createAccessToken(any(), any())).thenReturn("token");
 
         ResultActions actions = mockMvc.perform(post("/social/login/facebook")
                 .param("accessToken", "token")
@@ -103,7 +103,7 @@ class SocialControllerTest {
         when(oAuth2RequestService.getUserInfo(eq("token")))
                 .thenReturn(userInfoDTO);
         when(memberService.loginWithSocialProvider(userInfoDTO)).thenReturn(googleMember);
-        when(jwtHelper.createToken(any(), any())).thenReturn("token");
+        when(jwtHelper.createAccessToken(any(), any())).thenReturn("token");
 
         ResultActions actions = mockMvc.perform(post("/social/login/google")
                 .param("accessToken", "token")

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialControllerTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/oauth2/SocialControllerTest.java
@@ -64,7 +64,7 @@ class SocialControllerTest {
         when(jwtHelper.createAccessToken(any(), any())).thenReturn("token");
 
         ResultActions actions = mockMvc.perform(post("/social/login/github")
-                .param("accessToken", "token")
+                .param("token", "token")
                 .contentType(MediaType.APPLICATION_JSON)).andDo(print());
 
         actions
@@ -85,7 +85,7 @@ class SocialControllerTest {
         when(jwtHelper.createAccessToken(any(), any())).thenReturn("token");
 
         ResultActions actions = mockMvc.perform(post("/social/login/facebook")
-                .param("accessToken", "token")
+                .param("token", "token")
                 .contentType(MediaType.APPLICATION_JSON)).andDo(print());
 
         actions
@@ -106,7 +106,7 @@ class SocialControllerTest {
         when(jwtHelper.createAccessToken(any(), any())).thenReturn("token");
 
         ResultActions actions = mockMvc.perform(post("/social/login/google")
-                .param("accessToken", "token")
+                .param("token", "token")
                 .contentType(MediaType.APPLICATION_JSON)).andDo(print());
 
         actions
@@ -119,7 +119,7 @@ class SocialControllerTest {
         when(oAuth2RequestServiceFactory.getOAuth2RequestService("wrong"))
                 .thenThrow(new UnSupportedOAuth2Exception());
         ResultActions actions = mockMvc.perform(post("/social/login/wrong")
-                .param("accessToken", "token")
+                .param("token", "token")
                 .contentType(MediaType.APPLICATION_JSON)).andDo(print());
 
         actions

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/security/AuthControllerTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/security/AuthControllerTest.java
@@ -1,0 +1,57 @@
+package com.sproutt.eussyaeussyaapi.api.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(value = AuthController.class, includeFilters = @ComponentScan.Filter(classes = {Configuration.class}))
+public class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private JwtHelper jwtHelper;
+
+    @Test
+    @DisplayName("Refresh Token을 통해 새로운 Access Token을 발급 테스트")
+    void issue_new_access_token() throws Exception {
+        given(jwtHelper.isUsable(any(), any())).willReturn(true);
+
+        ResultActions actions = mvc.perform(post("/auth/accesstoken")
+                .header("Refresh-Authorization", "testtoken")
+                .contentType(MediaType.APPLICATION_JSON)).andDo(print());
+
+        actions
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 유효하지 않을 경우 발급 거부 테스트")
+    void invalid_refresh_token_test() throws Exception {
+        given(jwtHelper.isUsable(any(), any())).willReturn(false);
+
+        ResultActions actions = mvc.perform(post("/auth/accesstoken")
+                .header("Refresh-Authorization", "invalidtoken")
+                .contentType(MediaType.APPLICATION_JSON)).andDo(print());
+
+        actions
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/sproutt/eussyaeussyaapi/api/security/JwtHelperTest.java
+++ b/src/test/java/com/sproutt/eussyaeussyaapi/api/security/JwtHelperTest.java
@@ -1,7 +1,6 @@
 package com.sproutt.eussyaeussyaapi.api.security;
 
 import com.sproutt.eussyaeussyaapi.object.MemberFactory;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,7 +26,7 @@ class JwtHelperTest {
     @Test
     @DisplayName("토큰 생성이 잘 되는지 테스트")
     void create() {
-        String token = jwtHelper.createToken(secretKey, MemberFactory.getDefaultMember().toJwtInfo());
+        String token = jwtHelper.createAccessToken(secretKey, MemberFactory.getDefaultMember().toJwtInfo());
 
         assertThat(token == null).isFalse();
     }
@@ -35,7 +34,7 @@ class JwtHelperTest {
     @Test
     @DisplayName("생성된 토큰 유효성 테스트")
     void decrypt() {
-        String token = jwtHelper.createToken(secretKey, MemberFactory.getDefaultMember().toJwtInfo());
+        String token = jwtHelper.createAccessToken(secretKey, MemberFactory.getDefaultMember().toJwtInfo());
 
         assertThat(jwtHelper.isUsable(secretKey, token)).isTrue();
         assertThat(jwtHelper.decryptToken(secretKey, token).getNickName()).isEqualTo(MemberFactory.getDefaultMember().getNickName());


### PR DESCRIPTION
Refresh Token을 적용하였습니다. 
단 아직 완전한 적용은 아니고 Redis를 이용한 토큰 관리가 적용되어 있지 않아서, 별도의 PR을 통해 적용할 예정입니다.

### 주요 변경점
* 기존에 헤더를 통해 리턴해 주던 토큰을 이제 바디를 통해 리턴해 주도록 변경하였습니다.
* 기본적으로 로그인 사용자의 모든 요청은 기존처럼 Access Token을 통해 이루어지며 Access Token이 만료되어 POST /auth/accesstoken 을 통해 Access Token을 재발급 받을 때 Refresh Token이 사용됩니다.
* 로그인 시에는 Access Token과 Refresh Token 둘 다 발급 받으며, 이는 Local Storage에 저장됩니다.