### PR TITLE
[Back] 회원가입시 인증기능 제거 #123

### DIFF
--- a/src/main/java/com/sproutt/eussyaeussyaapi/application/member/MemberServiceImpl.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/application/member/MemberServiceImpl.java
@@ -49,15 +49,12 @@ public class MemberServiceImpl implements MemberService {
             throw new DuplicationMemberException();
         }
 
-        String authCode = RandomGenerator.createAuthenticationCode();
-        mailService.sendAuthEmail(memberJoinCommand.getMemberId(), authCode);
-
         Member member = Member.builder()
                               .memberId(memberJoinCommand.getMemberId())
                               .password(passwordEncoder.encode(memberJoinCommand.getPassword()))
                               .email(memberJoinCommand.getMemberId())
                               .nickName(memberJoinCommand.getNickName())
-                              .authentication(passwordEncoder.encode(authCode))
+                              .authentication("N")
                               .provider(Provider.LOCAL)
                               .build();
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,7 +53,7 @@ jasypt:
 
 api:
   cors:
-    allow-origins: ENC(MUx6CLsdon60zBEAbQ+k0aHjrEkt5/6olFrgs11l7Wjo1VwjzoumVltRKR133vMsTPAp6vQlrCLHZOqniOrBUg==)
+    allow-origins: https://eussya-eussya.com
 
 kafka:
   bootstrap-server: localhost:9092


### PR DESCRIPTION
- LocalProvicer 회원가입 로직에 인증 제거
- 인증기능 -> 기적용
- SocialProvicer 회원가입 시 기인증로직 유지

모든게 구현되어있어서 인증부분만 제거해서 별거 없는데요,
제가 잘못 이해하고있는거면 comment 부탁드립니다. 