### PR TITLE
[Bug] cors 이슈 해결 #134

### DIFF
--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/config/SecurityConfig.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/config/SecurityConfig.java
@@ -38,13 +38,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         this.jwtHelper = jwtHelper;
     }
 
-    private static final String[] PUBLIC = {"/auth/**", "/oauth2/**", "/signUp/**", "/phrase/**", "/members/**", "/login/**", "/webjars/**", "/swagger-resources/**", "/v2/**", "/email-auth/**", "/swagger-ui.html"};
+    private static final String[] PUBLIC = {"/auth/**", "/oauth2/**", "/signUp/**", "/phrase/**", "/members/**", "/login/**", "/email-auth/**"};
 
     @Override
     public void configure(WebSecurity web) {
         web
                 .ignoring()
-                .antMatchers("/members/**", "/login", "/webjars/**", "/swagger-resources/**", "/v2/**", "/swagger-ui.html")
+                .antMatchers("/webjars/**", "/swagger-resources/**", "/v2/**", "/swagger-ui.html")
                 .antMatchers("/error");
     }
 
@@ -54,6 +54,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .csrf()
                     .disable()
                 .formLogin()
+                    .disable()
+                .httpBasic()
                     .disable()
                 .cors()
                 .and()
@@ -89,6 +91,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         CorsConfiguration configuration = new CorsConfiguration();
 
         Arrays.stream(allowedOrigins.split(", ")).forEach(configuration::addAllowedOrigin);
+        configuration.addAllowedOrigin("http://kostat.go.kr");
         configuration.addAllowedMethod("*");
         configuration.addAllowedHeader("*");
         configuration.addExposedHeader(JwtHelper.ACCESS_TOKEN_HEADER);

--- a/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/api/security/JwtAuthenticationFilter.java
@@ -2,16 +2,15 @@ package com.sproutt.eussyaeussyaapi.api.security;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-public class JwtAuthenticationFilter extends GenericFilterBean {
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtHelper jwtHelper;
 
@@ -20,8 +19,8 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     }
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        String token = ((HttpServletRequest) request).getHeader(JwtHelper.ACCESS_TOKEN_HEADER);
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        String token = request.getHeader(JwtHelper.ACCESS_TOKEN_HEADER);
 
         if (token != null && jwtHelper.isUsable(token)) {
             Authentication authentication = jwtHelper.getAuthentication(token);
@@ -29,7 +28,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
                                  .setAuthentication(authentication);
         }
 
-        chain.doFilter(request, response);
+        filterChain.doFilter(request, response);
     }
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,7 +46,7 @@ jwt:
   secret: secret
 
 oauth2:
-  authorizedRedirectUrl: https://eussya-eussya.com/oauth/github
+  authorizedRedirectUrl: https://eussya-eussya.com/oauth/github/process
 
 
 jasypt:


### PR DESCRIPTION
**원인**
- configure(websecurity)로 ignoring 된 엔드포인트의 경우 시큐리티 보안 필터를 무시한다.
- configure(httpsecurity)에 cors preflight request로 인해 오는 OPTIONS 메소드 요청을 허용하는 설정이 들어있다.
- "/login", "/members/**" 와 같은 엔드포인트들이 websecurity로 igonoring 되고 있어서 시큐리티 보안 필터를 거치지 않고 있었기 때문에, OPTIONS 요청을 허용하지 않아 cors 이슈가 발생했음

**해결**
- websecurity ignoring 설정에서 OPTIONS 요청을 허용해야하는 엔드포인트를 제외시켰음

**참고**
- [https://stackoverflow.com/questions/56388865/spring-security-configuration-httpsecurity-vs-websecurity](https://stackoverflow.com/questions/56388865/spring-security-configuration-httpsecurity-vs-websecurity)