### PR TITLE
잔디(Activity) 기능 추가

### DIFF
--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/activity/Activity.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/activity/Activity.java
@@ -1,0 +1,50 @@
+package com.sproutt.eussyaeussyaapi.domain.activity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.time.LocalDate;
+
+import static javax.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Table(name="ACTIVITYS")
+@Getter
+public class Activity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name="ACTIVITY_ID")
+    private Long id;
+
+    @Column(name = "MEMBER_ID")
+    private String memberId;
+
+    @Column(name = "ACTIVITY_TYPE")
+    private ActivityType activityType;
+
+    @Column(name = "CREATED_DATE")
+    @CreatedDate
+    private LocalDate createdDate;
+
+    public Activity(String memberId, ActivityType activityType) {
+        this.memberId = memberId;
+        this.activityType = activityType;
+    }
+
+    @Builder
+    public Activity(Long id, String memberId, ActivityType activityType, LocalDate createdDate) {
+        this.id = id;
+        this.memberId = memberId;
+        this.activityType = activityType;
+        this.createdDate = createdDate;
+    }
+
+    Activity() {
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/activity/ActivityRepository.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/activity/ActivityRepository.java
@@ -1,0 +1,6 @@
+package com.sproutt.eussyaeussyaapi.domain.activity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityRepository extends JpaRepository<Activity, Long> {
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/activity/ActivityType.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/activity/ActivityType.java
@@ -1,0 +1,14 @@
+package com.sproutt.eussyaeussyaapi.domain.activity;
+
+public enum ActivityType {
+    ULDDO("01", "얼또"),
+    GROUP_TIL("02", "그룹TIL");
+
+    private final String code;
+    private final String description;
+
+    ActivityType(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/activity/AddActivityWithMissionCompleteEventHandler.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/activity/AddActivityWithMissionCompleteEventHandler.java
@@ -1,0 +1,24 @@
+package com.sproutt.eussyaeussyaapi.domain.activity;
+
+import com.sproutt.eussyaeussyaapi.domain.mission.MissionCompleteEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AddActivityWithMissionCompleteEventHandler {
+    private ActivityRepository activityRepository;
+
+    public AddActivityWithMissionCompleteEventHandler(ActivityRepository activityRepository) {
+        this.activityRepository = activityRepository;
+    }
+
+    @Async
+    @EventListener
+    @Transactional
+    public void handle(MissionCompleteEvent event) {
+        var activityType = ActivityType.ULDDO;
+        activityRepository.save(new Activity(event.getMemberId(), activityType));
+    }
+}

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/Mission.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/Mission.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.domain.AbstractAggregateRoot;
 
 import javax.persistence.*;
 import java.time.*;
@@ -18,7 +19,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor
-public class Mission {
+public class Mission extends AbstractAggregateRoot<Mission> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -132,6 +133,7 @@ public class Mission {
 
     public void complete() {
         this.status = MissionStatus.COMPLETE;
+        registerEvent(new MissionCompleteEvent(this));
     }
 
     public void updateRunningTime() {

--- a/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/MissionCompleteEvent.java
+++ b/src/main/java/com/sproutt/eussyaeussyaapi/domain/mission/MissionCompleteEvent.java
@@ -1,0 +1,14 @@
+package com.sproutt.eussyaeussyaapi.domain.mission;
+
+public class MissionCompleteEvent {
+    private Mission mission;
+
+    public MissionCompleteEvent(Mission mission) {
+        this.mission = mission;
+    }
+
+    public String getMemberId() {
+        return mission.getWriter()
+                      .getMemberId();
+    }
+}


### PR DESCRIPTION
### Description
* 잔디 기능을 위해 코드를 1차적으로 추가하였습니다.
* Ranking 구현하시는분과 데이터 구조와 인터페이스를 맞춰가기 위해 점진적인 PR 을 하겠습니다.
* 앞으로 으쌰으쌰에 등장할 여러 서비스들에 공통적으로 사용될 기능이기 때문에, 각 application layer code 에 Activity Domain의 의존성을 낮추기 위해 DomainEvent 방식으로 구현하였습니다.

### How to Test
* noting need to test.

### Commit
* design activity entity - c92462d
* eussya service별 activityType 구분 - 809ef0d
* AggregateRoot, DomainEvent 적용 - ab900f5