### PR TITLE
[Back] Profile 별 application.yml 설정 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.h2database:h2'
+    implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.22'
 
     implementation 'org.projectlombok:lombok'
     compileOnly "org.projectlombok:lombok"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,8 @@
-# DB
+
+# default profile
 spring:
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+  profiles:
+    active: local
 
   jpa:
     properties:
@@ -57,7 +56,6 @@ jwt:
 oauth2:
   authorizedRedirectUrl: https://eussya-eussya.com/oauth/github/process
 
-
 jasypt:
   encryptor:
     bean: jasyptStringEncryptor
@@ -82,8 +80,51 @@ cloud:
       profile:
         default: https://d3kjmjnyg8cjdl.cloudfront.net/default_profile.jpg
     cloudFront:
-        domain: https://d3kjmjnyg8cjdl.cloudfront.net/
+      domain: https://d3kjmjnyg8cjdl.cloudfront.net/
     region:
       static: ap-northeast-2
     stack:
       auto: false
+
+---
+
+# profile - local
+spring:
+  profiles: local
+  datasource:
+    driver-class-name: org.h2.Driver
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    hibernate:
+      ddl-auto: create
+
+---
+
+# profile - dev
+spring:
+  profiles: dev
+  datasource:
+    url: jdbc:mysql://localhost:3306/${DATABASE_NAME}?characterEncoding=UTF-8&serverTimezone=UTC
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+
+---
+
+# profile - real
+spring:
+  profiles: real
+  datasource:
+    url: jdbc:mysql://localhost:3306/${DATABASE_NAME}?characterEncoding=UTF-8&serverTimezone=UTC
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update


### PR DESCRIPTION
db 연결 이슈로 profile을 local, dev, real로 분리했습니다.
- local : h2 사용. ddl-auto: create
- dev : mysql 사용. ddl-auto: create
- real : mysql 사용. ddl-auto: update

mysql의 데이터베이스명, 유저네임, 패스워드는 외부 환경 변수로 읽어오도록 하였습니다. (서버 환경에 해당 변수 추가 작업 필요)
- 데이터베이스명 : DATABASE_NAME
- 유저네임 : DATABASE_USERNAME
- 패스워드 : DATABASE_PASSWORD